### PR TITLE
added subscription status to templates

### DIFF
--- a/payments/templates/payments/_subscription_status.html
+++ b/payments/templates/payments/_subscription_status.html
@@ -1,0 +1,35 @@
+{% with request.user.customer.current_subscription as subscription %}
+    {% if subscription.status == "active" %}
+        <div class="alert alert-info">
+            Your subscription will automatically renew in <strong>{{ subscription.period_end|timeuntil }}</strong>.
+        </div>
+    {% else %}
+        {% if subscription.status == "trialing" %}
+            {% if request.user.customer.plan and request.user.customer.card_kind %}
+                <div class="alert alert-info">
+                    Your free trial will end in <strong>{{ subscription.period_end|timeuntil }}</strong> after which you commence a <strong>{{ request.user.customer.display_plan }}</strong> plan.
+                </div>
+            {% else %}
+                <div class="alert alert-warning lead">
+                    Your free trial will end in <strong>{{ subscription.period_end|timeuntil }}</strong> after which you will need to get a subscription to continue using the site.
+                </div>
+            {% endif %}
+        {% else %}
+            {% if subscription.status == "canceled" %}
+                {% if subscription.is_period_current %}
+                    <div class="alert alert-warning lead">
+                        Your subscription has been <strong>canceled</strong> but you can continue to use the site for another <strong>{{ subscription.period_end|timeuntil }}</strong>.
+                    </div>
+                {% else %}
+                    <div class="alert alert-danger lead">
+                        Your subscription has been <strong>canceled</strong>.
+                    </div>
+                {% endif %}
+            {% else %}
+                <div class="alert alert-danger lead">
+                    Your subscription is <strong>{{ subscription.status }}</strong>.
+                </div>
+            {% endif %}
+        {% endif %}
+    {% endif %}
+{% endwith %}

--- a/payments/templates/payments/change_card.html
+++ b/payments/templates/payments/change_card.html
@@ -1,5 +1,6 @@
 {% extends "payments/base.html" %}
 
 {% block body %}
+    {% include "payments/_subscription_status.html" %}
     {% include "payments/_change_card_form.html" %}
 {% endblock %}

--- a/payments/templates/payments/change_plan.html
+++ b/payments/templates/payments/change_plan.html
@@ -1,5 +1,6 @@
 {% extends "payments/base.html" %}
 
 {% block body %}
+    {% include "payments/_subscription_status.html" %}
     {% include "payments/_change_plan_form.html" %}
 {% endblock %}

--- a/payments/templates/payments/history.html
+++ b/payments/templates/payments/history.html
@@ -1,6 +1,7 @@
 {% extends "payments/base.html" %}
 
 {% block body %}
+    {% include "payments/_subscription_status.html" %}
     <h2>Payment History</h2>
     <p class="lead">Your transaction history</p>
     {% if request.user.customer.charges.all %}

--- a/payments/templates/payments/subscribe.html
+++ b/payments/templates/payments/subscribe.html
@@ -1,5 +1,6 @@
 {% extends "payments/base.html" %}
 
 {% block body %}
+    {% include "payments/_subscription_status.html" %}
     {% include "payments/_subscribe_form.html" %}
 {% endblock %}


### PR DESCRIPTION
this provides a template snippet that shows subscription status such as:
- "Your subscription has been canceled."
- "Your subscription has been canceled but you can continue to use the site for another 1 day, 12 hours."
- "Your free trial will end in 6 days, 13 hours after which you will need to get a subscription to continue using the site."
- "Your free trial will end in 2 days, 8 hours after which you commence a Habitualist Monthly ($5/month) plan."

This snippet has been added to subscribe, change card, change plan and history templates.
