### PR TITLE
Add support for changing currency in Settings

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,6 +45,7 @@ Installation
             "name": "Web App Pro ($25/month)",
             "description": "The monthly subscription plan to WebApp",
             "price": 25,
+            "currency": "usd",
             "interval": "month"
         },
         "yearly": {
@@ -52,6 +53,7 @@ Installation
             "name": "Web App Pro ($199/year)",
             "description": "The annual subscription plan to WebApp",
             "price": 199,
+            "currency": "usd",
             "interval": "year"
         }
     }

--- a/payments/management/commands/init_plans.py
+++ b/payments/management/commands/init_plans.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
                     amount=100 * settings.PAYMENTS_PLANS[plan]["price"],
                     interval=settings.PAYMENTS_PLANS[plan]["interval"],
                     name=settings.PAYMENTS_PLANS[plan]["name"],
-                    currency="usd",
+                    currency=settings.PAYMENTS_PLANS[plan]["currency"],
                     id=settings.PAYMENTS_PLANS[plan].get("stripe_plan_id")
                 )
                 print "Plan created for %s" % plan

--- a/payments/models.py
+++ b/payments/models.py
@@ -383,7 +383,7 @@ class Customer(StripeObject):
             # It's just a single transaction
             resp = stripe.Charge.create(
                 amount=PAYMENTS_PLANS[plan]["price"] * 100,
-                currency="usd",
+                currency=settings.PAYMENTS_PLANS[plan]["currency"],
                 customer=self.stripe_id,
                 description=PAYMENTS_PLANS[plan]["name"]
             )


### PR DESCRIPTION
Stripe is now available in Canada so vendors are now able to choose to process in either American ("usd") and Canadian ("cad") currency.

At the moment, "usd" is hard-coded as the currency variable  which causes errors if your account is set to "cad". I've added currency as one of the variables in PAYMENT_PLANS allowing customers processing in Canadian dollars to specify "cad".

Stripe only allows one currency per account (this might change in the long term), so an alternative way to achieve this might be to set a single setting for PAYMENTS_CURRENCY, but I opted to minimize the number of SETTINGS and instead removed the hard-coding.
