### PR TITLE
Improved create customer

### DIFF
--- a/payments/management/commands/init_customers.py
+++ b/payments/management/commands/init_customers.py
@@ -3,20 +3,13 @@ from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
 
 from payments.models import Customer
-from payments.settings import TRIAL_PERIOD_FOR_USER_CALLBACK
-from payments.settings import DEFAULT_PLAN
 
 
 class Command(BaseCommand):
-    
+
     help = "Create customer objects for existing users that don't have one"
-    
+
     def handle(self, *args, **options):
         for user in User.objects.filter(customer__isnull=True):
-            trial_days = None
-            if TRIAL_PERIOD_FOR_USER_CALLBACK:
-                trial_days = TRIAL_PERIOD_FOR_USER_CALLBACK(user)
-            cus = Customer.create(user=user)
-            if DEFAULT_PLAN and trial_days:
-                cus.subscribe(plan=DEFAULT_PLAN, trial_days=trial_days)
+            Customer.create(user=user)
             print "Created customer for %s" % user.email


### PR DESCRIPTION
Made it so if the current user doesn't have a stripe customer associated with their account it will create one when they subscribe to a plan. This removes the need for running the init_customers management command when adding django-strip-payments to an existing project.
