### PR TITLE
Customer admin filter fix

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -54,7 +54,7 @@ class CustomerSubscriptionStatusListFilter(admin.SimpleListFilter):
         return statuses
 
     def queryset(self, request, queryset):
-        if self.value() == None:
+        if self.value() is None:
             return queryset.all()
         else:
             return queryset.filter(current_subscription__status=self.value())


### PR DESCRIPTION
A bug in the admin filter for customers made it seem like you didn't have any customers if all the current customers weren't subscribers yet.
