### PR TITLE
Update installation.rst with request context processor explanation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,6 +15,14 @@ You will also want to add ``django_forms_bootstrap`` to your `INSTALLED_APPS``::
         "django_forms_bootstrap",
     ]
 
+You will need to add the request context processor to TEMPLATE_CONTEXT_PROCESSORS
+if you wish to use the included templates by adding something like this in our
+settings.py:
+
+    TEMPLATE_CONTEXT_PROCESSORS += (
+        'django.core.context_processors.request',
+    )
+
 You will also want to add ``bootstrap-ajax.js`` to your base template. bootstrap-ajax_
 is a library used by the included templates to interact wiht the ajax views. You
 can certainly write your own javascript, but it is likely easier for you to just


### PR DESCRIPTION
I noticed that you use request.user in some of your templates, which will not work without the request context preprocessor.
