### PR TITLE
Don't refer directly to the User model when defining a Customer

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -308,7 +308,10 @@ class TransferChargeFee(models.Model):
 
 class Customer(StripeObject):
 
-    user = models.OneToOneField(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), null=True)
+    user = models.OneToOneField(
+        getattr(settings, "AUTH_USER_MODEL", "auth.User"),
+        null=True
+    )
     card_fingerprint = models.CharField(max_length=200, blank=True)
     card_last_4 = models.CharField(max_length=4, blank=True)
     card_kind = models.CharField(max_length=50, blank=True)


### PR DESCRIPTION
Fixes a potential issue if trying to add payments before the app where the custom User model is defined in the app cache.

Related to https://github.com/eldarion/django-stripe-payments/issues/73.
