### PR TITLE
Remove Django dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,6 @@ setup(
     install_requires=[
         "django-jsonfield>=0.8",
         "stripe>=1.7.9",
-        "django>=1.4"
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
This is a hack so I could use Django 1.6 which is not yet on PyPi. I'm not sure whether this is a good idea to have upstream – perhaps having Django installed is implied? I'm not sure whether these dependencies are used for any tests, etc.
