### PR TITLE
added raw_id_fields to EventProcessingException admin

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -149,6 +149,9 @@ admin.site.register(
         "traceback",
         "data"
     ],
+    raw_id_fields=[
+        "event"
+    ],
 )
 
 admin.site.register(


### PR DESCRIPTION
This fixes extremely long load times on sites with many `Event` objects when viewing an exception.
