### PR TITLE
Changed SEND_EMAIL_RECEIPTS default to False

### DIFF
--- a/payments/settings.py
+++ b/payments/settings.py
@@ -38,7 +38,7 @@ if isinstance(TRIAL_PERIOD_FOR_USER_CALLBACK, basestring):
 if isinstance(PLAN_QUANTITY_CALLBACK, basestring):
     PLAN_QUANTITY_CALLBACK = load_path_attr(PLAN_QUANTITY_CALLBACK)
 
-SEND_EMAIL_RECEIPTS = getattr(settings, "SEND_EMAIL_RECEIPTS", True)
+SEND_EMAIL_RECEIPTS = getattr(settings, "SEND_EMAIL_RECEIPTS", False)
 
 
 def plan_from_stripe_id(stripe_id):


### PR DESCRIPTION
I'd be curious to get other perspectives on this but I think False would be a better default for this setting. It certainly caught me off guard when I realized this was sending emails that I didn't know about, especially considering this isn't anywhere in the documentation yet.
