### PR TITLE
Add support for Django 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 env:
   - DJANGO=1.4
   - DJANGO=1.5
+  - DJANGO=1.6
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install -q django-jsonfield==0.8.12

--- a/payments/models.py
+++ b/payments/models.py
@@ -606,7 +606,7 @@ class CurrentSubscription(models.Model):
     start = models.DateTimeField()
     # trialing, active, past_due, canceled, or unpaid
     status = models.CharField(max_length=25)
-    cancel_at_period_end = models.BooleanField()
+    cancel_at_period_end = models.BooleanField(default=False)
     canceled_at = models.DateTimeField(null=True)
     current_period_end = models.DateTimeField(null=True)
     current_period_start = models.DateTimeField(null=True)

--- a/runtests.py
+++ b/runtests.py
@@ -6,6 +6,7 @@ from django.conf import settings
 settings.configure(
     DEBUG=True,
     USE_TZ=True,
+    TIME_ZONE='UTC',
     DATABASES={
         "default": {
             "ENGINE": "django.db.backends.sqlite3",

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,8 @@ setup(
     install_requires=[
         "django-jsonfield>=0.8",
         "stripe>=1.7.9",
-        "django>=1.4"
+        "django>=1.4",
+        "pytz"
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Three changes required:
- BooleanField no longer defaults to False
- filter(date__month=..., date__day=...) is now timezone aware, so
  a timezone needs to be specified in the settings
- it now seems to require pytz, probably because of timezone
  awareness
