### PR TITLE
Fixes for #103 test suits failed

### DIFF
--- a/payments/tests/test_middleware.py
+++ b/payments/tests/test_middleware.py
@@ -29,6 +29,7 @@ class ActiveSubscriptionMiddlewareTests(TestCase):
     def setUp(self):
         self.middleware = ActiveSubscriptionMiddleware()
         self.request = Mock()
+        self.request.META = {}
         self.request.session = DummySession()
         user = get_user_model().objects.create_user(username="patrick")
         user.set_password("eldarion")

--- a/payments/tests/test_templatetags.py
+++ b/payments/tests/test_templatetags.py
@@ -18,6 +18,7 @@ class PaymentsTagTests(TestCase):
 
     def test_change_plan_form(self):
         request = Mock()
+        request.META = {}
         request.session = DummySession()
         user = get_user_model().objects.create_user(username="patrick")
         user.set_password("eldarion")


### PR DESCRIPTION
The error is due to `request.META` is a `Mock` object.
Initialise `request.META` as a dictionary can eliminate the error.

Fixes #103
