### PR TITLE
Deleted subscriptions fix

### DIFF
--- a/pinax/stripe/actions/syncs.py
+++ b/pinax/stripe/actions/syncs.py
@@ -214,6 +214,7 @@ def _sync_invoice_items(invoice_proxy, items):
                 setattr(inv_item, key, defaults[key])
             inv_item.save()
 
+
 def _retrieve_stripe_subscription(customer, sub_id):
     if sub_id:
         try:
@@ -226,6 +227,7 @@ def _retrieve_stripe_subscription(customer, sub_id):
             else:
                 # The exception was raised for another reason, re-raise it
                 raise
+
 
 def sync_invoice_from_stripe_data(stripe_invoice, send_receipt=settings.PINAX_STRIPE_SEND_EMAIL_RECEIPTS):
     c = proxies.CustomerProxy.objects.get(stripe_id=stripe_invoice["customer"])

--- a/pinax/stripe/actions/syncs.py
+++ b/pinax/stripe/actions/syncs.py
@@ -210,6 +210,25 @@ def _sync_invoice_items(invoice_proxy, items):
                 setattr(inv_item, key, defaults[key])
             inv_item.save()
 
+def _retrieve_subscription(customer, sub_id):
+    if sub_id:
+        try:
+            stripe_subscription = customer.stripe_customer.subscriptions\
+                                                          .retrieve(sub_id)
+            subscription = sync_subscription_from_stripe_data(
+                customer, stripe_subscription)
+        except stripe.InvalidRequestError as e:
+            if smart_str(e).find("does not have a subscription with ID") != -1:
+                # The exception was thrown because the customer has deleted the
+                # subscription we're attempting to sync, ignore the exception
+                subscription = None
+            else:
+                # The exception was raised for another reason, re-raise it
+                raise
+    else:
+        subscription = None
+
+    return subscription
 
 def sync_invoice_from_stripe_data(stripe_invoice, send_receipt=settings.PINAX_STRIPE_SEND_EMAIL_RECEIPTS):
     c = proxies.CustomerProxy.objects.get(stripe_id=stripe_invoice["customer"])
@@ -225,22 +244,8 @@ def sync_invoice_from_stripe_data(stripe_invoice, send_receipt=settings.PINAX_ST
     else:
         charge = None
 
-    if sub_id:
-        try:
-            stripe_subscription = c.stripe_customer.subscriptions\
-                                                   .retrieve(sub_id)
-            subscription = sync_subscription_from_stripe_data(
-                c, stripe_subscription)
-        except stripe.InvalidRequestError as e:
-            if smart_str(e).find("does not have a subscription with ID") != -1:
-                # The exception was thrown because the customer has deleted the
-                # subscription we're attempting to sync, ignore the exception
-                subscription = None
-            else:
-                # The exception was raised for another reason, re-raise it
-                raise
-    else:
-        subscription = None
+    subscription = sync_subscription_from_stripe_data(
+        c, _retrieve_subscription(c, sub_id)) if sub_id else None
 
     defaults = dict(
         customer=c,

--- a/pinax/stripe/actions/syncs.py
+++ b/pinax/stripe/actions/syncs.py
@@ -182,10 +182,14 @@ def _sync_invoice_items(invoice_proxy, items):
             if invoice_proxy.subscription and invoice_proxy.subscription.stripe_id == item["id"]:
                 item_subscription = invoice_proxy.subscription
             else:
+                stripe_subscription = _retrieve_stripe_subscription(
+                    invoice_proxy.customer,
+                    item["id"]
+                )
                 item_subscription = sync_subscription_from_stripe_data(
                     invoice_proxy.customer,
-                    invoice_proxy.customer.stripe_customer.subscriptions.retrieve(item["id"])
-                )
+                    stripe_subscription
+                ) if stripe_subscription else None
         else:
             item_subscription = None
 

--- a/pinax/stripe/actions/syncs.py
+++ b/pinax/stripe/actions/syncs.py
@@ -1,3 +1,5 @@
+from django.utils.encoding import smart_str
+
 import stripe
 
 from ..conf import settings
@@ -223,7 +225,22 @@ def sync_invoice_from_stripe_data(stripe_invoice, send_receipt=settings.PINAX_ST
     else:
         charge = None
 
-    subscription = sync_subscription_from_stripe_data(c, c.stripe_customer.subscriptions.retrieve(sub_id)) if sub_id else None
+    if sub_id:
+        try:
+            stripe_subscription = c.stripe_customer.subscriptions\
+                                                   .retrieve(sub_id)
+            subscription = sync_subscription_from_stripe_data(
+                c, stripe_subscription)
+        except stripe.InvalidRequestError as e:
+            if smart_str(e).find("does not have a subscription with ID") != -1:
+                # The exception was thrown because the customer has deleted the
+                # subscription we're attempting to sync, ignore the exception
+                subscription = None
+            else:
+                # The exception was raised for another reason, re-raise it
+                raise
+    else:
+        subscription = None
 
     defaults = dict(
         customer=c,


### PR DESCRIPTION
If a DELETE request is made to the subscriptions API, syncing breaks during `python manage.py sync_customers`.

This was because invoices for the customer that are synced and refer to the subscription ID of now-deleted subscriptions. This happened in two separate places: syncing the invoice, as well as the invoice-items. 

The solution I came up with wraps the stripe_customer.subscriptions.retrieve(sub_id) in a helper function (_retrieve_stripe_subscription) that encapsulates the call in a try-except block which ignores the invalid/deleted subscription ID. Then, subsequent calls to sync the stripe_subscription can be bypassed if the retrieve failed (_retrieve_stripe_subscription returns None).