### PR TITLE
Support Django master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,17 @@ env:
   - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
+  - DJANGO=master
 matrix:
   exclude:
     - python: "3.2"
       env: DJANGO=1.9
     - python: "3.3"
       env: DJANGO=1.9
+    - python: "3.2"
+      env: DJANGO=master
+    - python: "3.3"
+      env: DJANGO=master
     - python: "3.5"
       env: DJANGO=1.7
 install:

--- a/runtests.py
+++ b/runtests.py
@@ -6,6 +6,7 @@ import django
 
 from django.conf import settings
 
+old = django.VERSION < (1, 8)
 
 DEFAULT_SETTINGS = dict(
     DEBUG=True,
@@ -50,12 +51,12 @@ DEFAULT_SETTINGS = dict(
             "debug": True,
             "context_processors": [
                 "django.contrib.auth.context_processors.auth",
-                "django.core.context_processors.debug",
-                "django.core.context_processors.i18n",
-                "django.core.context_processors.media",
-                "django.core.context_processors.static",
-                "django.core.context_processors.tz",
-                "django.core.context_processors.request"
+                "django.{}.context_processors.debug".format("core" if old else "template"),
+                "django.{}.context_processors.i18n".format("core" if old else "template"),
+                "django.{}.context_processors.media".format("core" if old else "template"),
+                "django.{}.context_processors.static".format("core" if old else "template"),
+                "django.{}.context_processors.tz".format("core" if old else "template"),
+                "django.{}.context_processors.request".format("core" if old else "template")
             ],
         },
     }]

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     ],
     install_requires=[
         "django-appconf>=1.0.1",
-        "django-jsonfield>=0.9.15",
+        "jsonfield>=1.0.3",
         "stripe>=1.7.9",
         "django>=1.7",
         "pytz",

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@ exclude = pinax/stripe/migrations/*
 
 [tox]
 envlist =
-    py27-1.7, py27-1.8, py27-1.9,
+    py27-1.7, py27-1.8, py27-1.9, py27-master,
     py32-1.7, py32-1.8,
     py33-1.7, py33-1.8,
-    py34-1.7, py34-1.8, py34-1.9,
-    py35-1.8, py35-1.9,
+    py34-1.7, py34-1.8, py34-1.9, py34-master,
+    py35-1.8, py35-1.9, py35-master
 
 [testenv]
 deps =
@@ -22,8 +22,8 @@ setenv =
    LANGUAGE=en_US:en
    LC_ALL=en_US.UTF-8
 commands =
-  flake8 pinax
-  coverage run setup.py test
+    flake8 pinax
+    coverage run setup.py test
 
 [testenv:py27-1.7]
 basepython = python2.7
@@ -42,6 +42,12 @@ basepython = python2.7
 deps =
     {[testenv]deps}
     https://github.com/django/django/tarball/stable/1.9.x
+
+[testenv:py27-master]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    https://github.com/django/django/tarball/master
 
 [testenv:py32-1.7]
 basepython = python3.2
@@ -87,6 +93,12 @@ deps =
     {[testenv]deps}
     https://github.com/django/django/tarball/stable/1.9.x
 
+[testenv:py34-master]
+basepython = python3.4
+deps =
+    {[testenv]deps}
+    https://github.com/django/django/tarball/master
+
 [testenv:py35-1.8]
 basepython = python3.5
 deps =
@@ -98,3 +110,9 @@ basepython = python3.5
 deps =
     {[testenv]deps}
     https://github.com/django/django/tarball/stable/1.9.x
+
+[testenv:py35-master]
+basepython = python3.5
+deps =
+    {[testenv]deps}
+    https://github.com/django/django/tarball/master


### PR DESCRIPTION
1.10 has a number of breaking changes, most notable as far as it concerns this package is `SubfieldBase` and our reliance on `django-jsonfield`. We have used this throughout Pinax for a long time but this package marks the start of the switch over to `jsonfield` in order to gain compatibility with Django 1.10.

At this point, I'm not sure how to make the package that is used decided upon outside of `pinax-stripe`.