### PR TITLE
Use a Form in PaymentMethodUpdateView

### DIFF
--- a/pinax/stripe/forms.py
+++ b/pinax/stripe/forms.py
@@ -3,5 +3,11 @@ from django import forms
 from .models import Plan
 
 
+class PaymentMethodForm(forms.Form):
+
+    expMonth = forms.IntegerField(min_value=1, max_value=12)
+    expYear = forms.IntegerField(min_value=2015, max_value=9999)
+
+
 class PlanForm(forms.Form):
     plan = forms.ModelChoiceField(queryset=Plan.objects.all())

--- a/pinax/stripe/tests/test_views.py
+++ b/pinax/stripe/tests/test_views.py
@@ -224,6 +224,19 @@ class PaymentMethodUpdateViewTests(TestCase):
         self.assertRedirects(response, reverse("pinax_stripe_payment_method_list"))
 
     @patch("pinax.stripe.actions.sources.update_card")
+    def test_post_invalid_form(self, CreateMock):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.post(
+            reverse("pinax_stripe_payment_method_update", args=[self.card.pk]),
+            {
+                "expMonth": 13,
+                "expYear": 2014
+            }
+        )
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.context_data["form"].is_valid(), False)
+
+    @patch("pinax.stripe.actions.sources.update_card")
     def test_post_on_error(self, CreateMock):
         CreateMock.side_effect = stripe.CardError("Bad card", "Param", "CODE")
         self.client.login(username=self.user.username, password=self.password)

--- a/pinax/stripe/tests/test_views.py
+++ b/pinax/stripe/tests/test_views.py
@@ -215,7 +215,10 @@ class PaymentMethodUpdateViewTests(TestCase):
         self.client.login(username=self.user.username, password=self.password)
         response = self.client.post(
             reverse("pinax_stripe_payment_method_update", args=[self.card.pk]),
-            {}
+            {
+                "expMonth": 1,
+                "expYear": 2018
+            }
         )
         self.assertEquals(response.status_code, 302)
         self.assertRedirects(response, reverse("pinax_stripe_payment_method_list"))

--- a/pinax/stripe/views.py
+++ b/pinax/stripe/views.py
@@ -74,12 +74,19 @@ class PaymentMethodUpdateView(LoginRequiredMixin, CustomerMixin, PaymentsContext
         sources.update_card(self.customer, self.object.stripe_id, exp_month=exp_month, exp_year=exp_year)
 
     def form_valid(self, form):
-        self.object = self.get_object()
         try:
             self.update_card(form.cleaned_data["expMonth"], form.cleaned_data["expYear"])
             return redirect("pinax_stripe_payment_method_list")
         except stripe.CardError as e:
             return self.render_to_response(self.get_context_data(errors=smart_str(e)))
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        form = self.get_form(form_class=self.form_class)
+        if form.is_valid():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
 
 
 class SubscriptionListView(LoginRequiredMixin, CustomerMixin, ListView):


### PR DESCRIPTION
The view `PaymentMethodUpdateView` handles unvalidated user input that is passed directly to the stripe api call to update a credit card.

This PR adds a Form that validates the input in `PaymentMethodUpdateView`.