### PR TITLE
Support more than the default plan page size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,32 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO=1.7
-  - DJANGO=1.8
-  - DJANGO=1.9
-  - DJANGO=master
+  - DJANGO=1.7 STRIPE=127
+  - DJANGO=1.7 STRIPE=128
+  - DJANGO=1.8 STRIPE=127
+  - DJANGO=1.8 STRIPE=128
+  - DJANGO=1.9 STRIPE=127
+  - DJANGO=1.9 STRIPE=128
+  - DJANGO=master STRIPE=127
+  - DJANGO=master STRIPE=128
 matrix:
   exclude:
     - python: "3.3"
-      env: DJANGO=1.9
+      env: DJANGO=1.9 STRIPE=127
     - python: "3.3"
-      env: DJANGO=master
+      env: DJANGO=1.9 STRIPE=128
+    - python: "3.3"
+      env: DJANGO=master STRIPE=127
+    - python: "3.3"
+      env: DJANGO=master STRIPE=128
     - python: "3.5"
-      env: DJANGO=1.7
+      env: DJANGO=1.7 STRIPE=127
+    - python: "3.5"
+      env: DJANGO=1.7 STRIPE=128
 install:
   - pip install tox coveralls
 script:
-  - tox -e py${TRAVIS_PYTHON_VERSION//[.]/}-$DJANGO
+  - tox -e py${TRAVIS_PYTHON_VERSION//[.]/}-$DJANGO-stripe${STRIPE}
 after_success:
   - coveralls
 notifications:

--- a/pinax/stripe/actions/plans.py
+++ b/pinax/stripe/actions/plans.py
@@ -8,7 +8,12 @@ def sync_plans():
     """
     Syncronizes all plans from the Stripe API
     """
-    for plan in stripe.Plan.all().data:
+    try:
+        plans = stripe.Plan.auto_paging_iter()
+    except AttributeError:
+        plans = iter(stripe.Plan.all().data)
+
+    for plan in plans:
         defaults = dict(
             amount=utils.convert_amount_for_db(plan["amount"], plan["currency"]),
             currency=plan["currency"] or "",

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -642,7 +642,7 @@ class SyncsTests(TestCase):
         )
 
     @patch("stripe.Plan.all")
-    @patch("stripe.Plan.auto_paging_iter", side_effect=AttributeError)
+    @patch("stripe.Plan.auto_paging_iter", create=True, side_effect=AttributeError)
     def test_sync_plans_deprecated(self, PlanAutoPagerMock, PlanAllMock):
         PlanAllMock().data = [
             {
@@ -678,7 +678,7 @@ class SyncsTests(TestCase):
         self.assertTrue(Plan.objects.all().count(), 2)
         self.assertEquals(Plan.objects.get(stripe_id="simple1").amount, decimal.Decimal("9.99"))
 
-    @patch("stripe.Plan.auto_paging_iter")
+    @patch("stripe.Plan.auto_paging_iter", create=True)
     def test_sync_plans(self, PlanAutoPagerMock):
         PlanAutoPagerMock.return_value = [
             {
@@ -714,7 +714,7 @@ class SyncsTests(TestCase):
         self.assertTrue(Plan.objects.all().count(), 2)
         self.assertEquals(Plan.objects.get(stripe_id="simple1").amount, decimal.Decimal("9.99"))
 
-    @patch("stripe.Plan.auto_paging_iter")
+    @patch("stripe.Plan.auto_paging_iter", create=True)
     def test_sync_plans_update(self, PlanAutoPagerMock):
         PlanAutoPagerMock.return_value = [
             {

--- a/pinax/stripe/tests/test_commands.py
+++ b/pinax/stripe/tests/test_commands.py
@@ -33,7 +33,7 @@ class CommandTests(TestCase):
         self.assertEquals(customer.stripe_id, "cus_XXXXX")
 
     @patch("stripe.Plan.all")
-    @patch("stripe.Plan.auto_paging_iter", side_effect=AttributeError)
+    @patch("stripe.Plan.auto_paging_iter", create=True, side_effect=AttributeError)
     def test_plans_create_deprecated(self, PlanAutoPagerMock, PlanAllMock):
         PlanAllMock().data = [{
             "id": "entry-monthly",
@@ -50,7 +50,7 @@ class CommandTests(TestCase):
         self.assertEquals(Plan.objects.all()[0].stripe_id, "entry-monthly")
         self.assertEquals(Plan.objects.all()[0].amount, decimal.Decimal("9.54"))
 
-    @patch("stripe.Plan.auto_paging_iter")
+    @patch("stripe.Plan.auto_paging_iter", create=True)
     def test_plans_create(self, PlanAutoPagerMock):
         PlanAutoPagerMock.return_value = [{
             "id": "entry-monthly",

--- a/pinax/stripe/tests/test_commands.py
+++ b/pinax/stripe/tests/test_commands.py
@@ -33,8 +33,26 @@ class CommandTests(TestCase):
         self.assertEquals(customer.stripe_id, "cus_XXXXX")
 
     @patch("stripe.Plan.all")
-    def test_plans_create(self, PlanAllMock):
+    @patch("stripe.Plan.auto_paging_iter", side_effect=AttributeError)
+    def test_plans_create_deprecated(self, PlanAutoPagerMock, PlanAllMock):
         PlanAllMock().data = [{
+            "id": "entry-monthly",
+            "amount": 954,
+            "interval": "monthly",
+            "interval_count": 1,
+            "currency": None,
+            "statement_descriptor": None,
+            "trial_period_days": None,
+            "name": "Pro"
+        }]
+        management.call_command("sync_plans")
+        self.assertEquals(Plan.objects.count(), 1)
+        self.assertEquals(Plan.objects.all()[0].stripe_id, "entry-monthly")
+        self.assertEquals(Plan.objects.all()[0].amount, decimal.Decimal("9.54"))
+
+    @patch("stripe.Plan.auto_paging_iter")
+    def test_plans_create(self, PlanAutoPagerMock):
+        PlanAutoPagerMock.return_value = [{
             "id": "entry-monthly",
             "amount": 954,
             "interval": "monthly",

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,16 @@ exclude = pinax/stripe/migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.7,1.8,1.9,master},
-    py33-{1.7,1.8},
-    py34-{1.7,1.8,1.9,master},
-    py35-{1.8,1.9,master}
+    py27-{1.7,1.8,1.9,master}-stripe{127,128},
+    py33-{1.7,1.8}-stripe{127,128},
+    py34-{1.7,1.8,1.9,master}-stripe{127,128},
+    py35-{1.8,1.9,master}-stripe{127,128}
 
 [testenv]
 deps =
     py{27,33,34,35}: coverage == 4.0.2
+    stripe127: stripe<1.28.0
+    stripe128: stripe>=1.28.0
     flake8 == 2.5.0
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9


### PR DESCRIPTION
python-stripe introduced a new iterator interface for results in 1.28.0,
and deprecated the `all()` accessor. In addition, there is a method to
automatically page over all results.

https://github.com/stripe/stripe-python/blob/efe1ecc575ad97d22ad6381ee1f6686f34fc27b1/CHANGELOG#L17

For accounts with large numbers of Plans, only the first 10 would get
synced before this change.