### PR TITLE
Ignore customers who might be test customers

### DIFF
--- a/pinax/stripe/tests/test_commands.py
+++ b/pinax/stripe/tests/test_commands.py
@@ -4,6 +4,7 @@ from django.core import management
 from django.test import TestCase
 
 from django.contrib.auth import get_user_model
+from stripe.error import InvalidRequestError
 
 from mock import patch
 
@@ -79,4 +80,21 @@ class CommandTests(TestCase):
         management.call_command("sync_customers")
         self.assertEqual(SyncChargesMock.call_count, 2)
         self.assertEqual(SyncInvoicesMock.call_count, 2)
+        self.assertEqual(SyncMock.call_count, 2)
+
+    @patch("stripe.Customer.retrieve")
+    @patch("pinax.stripe.actions.customers.sync_customer")
+    @patch("pinax.stripe.actions.invoices.sync_invoices_for_customer")
+    @patch("pinax.stripe.actions.charges.sync_charges_for_customer")
+    def test_sync_customers_with_test_customer(self, SyncChargesMock, SyncInvoicesMock, SyncMock, RetrieveMock):
+        user2 = get_user_model().objects.create_user(username="thomas")
+        get_user_model().objects.create_user(username="altman")
+        Customer.objects.create(stripe_id="cus_XXXXX", user=self.user)
+        Customer.objects.create(stripe_id="cus_YYYYY", user=user2)
+
+        SyncMock.side_effect = InvalidRequestError('Unknown customer', None, http_status=404)
+
+        management.call_command("sync_customers")
+        self.assertEqual(SyncChargesMock.call_count, 0)
+        self.assertEqual(SyncInvoicesMock.call_count, 0)
         self.assertEqual(SyncMock.call_count, 2)


### PR DESCRIPTION
We could examine to see if the message also contains `a similar object exists in test mode`, but wasn't sure if that was something I should also do.