### PR TITLE
Only import django.contrib.sites if it is required

### DIFF
--- a/pinax/stripe/hooks.py
+++ b/pinax/stripe/hooks.py
@@ -1,8 +1,6 @@
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
 
-from django.contrib.sites.models import Site
-
 
 class DefaultHookSet(object):
 
@@ -30,6 +28,9 @@ class DefaultHookSet(object):
     def send_receipt(self, charge):
         from django.conf import settings
         if not charge.receipt_sent:
+            # Import here to not add a hard dependency on the Sites framework
+            from django.contrib.sites.models import Site
+
             site = Site.objects.get_current()
             protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
             ctx = {

--- a/pinax/stripe/tests/hooks.py
+++ b/pinax/stripe/tests/hooks.py
@@ -5,8 +5,6 @@ from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
 from django.utils import timezone
 
-from django.contrib.sites.models import Site
-
 from ..hooks import DefaultHookSet
 
 
@@ -34,6 +32,8 @@ class TestHookSet(DefaultHookSet):
 
     def send_receipt(self, charge):
         if not charge.receipt_sent:
+            from django.contrib.sites.models import Site
+
             site = Site.objects.get_current()
             protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
             ctx = {


### PR DESCRIPTION
Some sites may not need the extra dependency (if they send their own
receipts, for example).