### PR TITLE
change related name of Customer-User relation to "stripe_customer"

### DIFF
--- a/pinax/stripe/actions/charges.py
+++ b/pinax/stripe/actions/charges.py
@@ -41,7 +41,7 @@ def capture(charge, amount=None):
     sync_charge_from_stripe_data(stripe_charge)
 
 
-def create(amount, customer, source=None, currency="usd", description=None, send_receipt=settings.PINAX_STRIPE_SEND_EMAIL_RECEIPTS, capture=True):
+def create(amount, customer, source=None, currency="usd", description=None, send_receipt=settings.PINAX_STRIPE_SEND_EMAIL_RECEIPTS, capture=True, idempotency_key=None):
     """
     Creates a charge for the given customer.
 
@@ -68,6 +68,7 @@ def create(amount, customer, source=None, currency="usd", description=None, send
         customer=customer,
         description=description,
         capture=capture,
+        idempotency_key=idempotency_key,
     )
     charge = sync_charge_from_stripe_data(stripe_charge)
     if send_receipt:

--- a/pinax/stripe/actions/charges.py
+++ b/pinax/stripe/actions/charges.py
@@ -41,7 +41,7 @@ def capture(charge, amount=None):
     sync_charge_from_stripe_data(stripe_charge)
 
 
-def create(amount, customer, source=None, currency="usd", description=None, send_receipt=settings.PINAX_STRIPE_SEND_EMAIL_RECEIPTS, capture=True, idempotency_key=None):
+def create(amount, customer, source=None, currency="usd", description=None, send_receipt=settings.PINAX_STRIPE_SEND_EMAIL_RECEIPTS, capture=True, idempotency_key=None, metadata=None):
     """
     Creates a charge for the given customer.
 
@@ -69,6 +69,7 @@ def create(amount, customer, source=None, currency="usd", description=None, send
         description=description,
         capture=capture,
         idempotency_key=idempotency_key,
+        metadata=metadata,
     )
     charge = sync_charge_from_stripe_data(stripe_charge)
     if send_receipt:

--- a/pinax/stripe/models.py
+++ b/pinax/stripe/models.py
@@ -96,7 +96,7 @@ class TransferChargeFee(models.Model):
 @python_2_unicode_compatible
 class Customer(StripeObject):
 
-    user = models.OneToOneField(settings.AUTH_USER_MODEL, null=True)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, null=True, related_name='stripe_customer')
     account_balance = models.DecimalField(decimal_places=2, max_digits=9, null=True)
     currency = models.CharField(max_length=10, default="usd", blank=True)
     delinquent = models.BooleanField(default=False)


### PR DESCRIPTION
Hello Pinax Team,

This Pull-request changes the related_name of the Customer <--> User relation to "stripe_customer". We are using multiple services that require our users to be "customers" in many ways (CRM System, AdTracking etc), so having a "customer" field is ambigious.