### PR TITLE
Sync subscription on cancel

### DIFF
--- a/pinax/stripe/tests/test_event.py
+++ b/pinax/stripe/tests/test_event.py
@@ -20,6 +20,14 @@ class TestEventMethods(TestCase):
             stripe_id="cus_xxxxxxxxxxxxxxx",
             user=self.user
         )
+        self.plan = Plan.objects.create(
+            stripe_id="p1",
+            amount=10,
+            currency="usd",
+            interval="monthly",
+            interval_count=1,
+            name="Pro"
+        )
 
     def test_link_customer_customer_created(self):
         msg = {
@@ -217,14 +225,8 @@ class TestEventMethods(TestCase):
         cm.default_source = ""
         cm.account_balance = 0
         kind = "customer.subscription.deleted"
-        plan = Plan.objects.create(
-            stripe_id="p1",
-            amount=10,
-            currency="usd",
-            interval="monthly",
-            interval_count=1,
-            name="Pro"
-        )
+        plan = self.plan
+
         cs = Subscription(stripe_id="su_2ZDdGxJ3EQQc7Q", customer=self.customer, quantity=1, start=timezone.now(), plan=plan)
         cs.save()
         customer = Customer.objects.get(pk=self.customer.pk)
@@ -247,7 +249,7 @@ class TestEventMethods(TestCase):
                         "name": "xxx",
                         "amount": 200,
                         "currency": "usd",
-                        "id": "xxx",
+                        "id": plan.stripe_id,
                         "object": "plan",
                         "livemode": True,
                         "interval_count": 1,

--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -303,10 +303,11 @@ class CustomerSourceUpdatedWebhook(CustomerSourceWebhook):
 class CustomerSubscriptionWebhook(Webhook):
 
     def process_webhook(self):
-        subscriptions.sync_subscription_from_stripe_data(
-            self.event.customer,
-            self.event.validated_message["data"]["object"]
-        )
+        if self.event.validated_message:
+            subscriptions.sync_subscription_from_stripe_data(
+                self.event.customer,
+                self.event.validated_message["data"]["object"]
+            )
 
         if self.event.customer:
             customers.sync_customer(self.event.customer, self.event.customer.stripe_customer)

--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -6,7 +6,7 @@ import stripe
 
 from six import with_metaclass
 
-from .actions import charges, customers, exceptions, invoices, transfers, sources
+from .actions import charges, customers, exceptions, invoices, transfers, sources, subscriptions
 from .conf import settings
 
 
@@ -303,6 +303,11 @@ class CustomerSourceUpdatedWebhook(CustomerSourceWebhook):
 class CustomerSubscriptionWebhook(Webhook):
 
     def process_webhook(self):
+        subscriptions.sync_subscription_from_stripe_data(
+            self.event.customer,
+            self.event.validated_message["data"]["object"]
+        )
+
         if self.event.customer:
             customers.sync_customer(self.event.customer, self.event.customer.stripe_customer)
 


### PR DESCRIPTION
Updated code to make sure we don't fail when there is no validated_message. Also updated the plan in the message for the test_event.py file so that a plan can be found when updating the subscription.