### PR TITLE
Methods/manager for Subscriptions

### DIFF
--- a/pinax/stripe/managers.py
+++ b/pinax/stripe/managers.py
@@ -71,3 +71,12 @@ class ChargeManager(models.Manager):
             total_amount=models.Sum("amount"),
             total_refunded=models.Sum("amount_refunded")
         )
+
+
+class SubscriptionManager(models.Manager):
+
+    def current_subscriptions(self, plan=1):
+        return self.filter(
+            status__in=["trialing", "active"],
+            plan=plan
+        )

--- a/pinax/stripe/migrations/0006_auto_20161202_1454.py
+++ b/pinax/stripe/migrations/0006_auto_20161202_1454.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pinax_stripe', '0005_auto_20161006_1445'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='subscription',
+            name='customer',
+            field=models.ForeignKey(related_name='subscriptions', to='pinax_stripe.Customer'),
+        ),
+    ]

--- a/pinax/stripe/models.py
+++ b/pinax/stripe/models.py
@@ -11,7 +11,7 @@ import stripe
 from jsonfield.fields import JSONField
 
 from .conf import settings
-from .managers import ChargeManager, CustomerManager
+from .managers import ChargeManager, CustomerManager, SubscriptionManager
 from .utils import CURRENCY_SYMBOLS
 
 
@@ -174,9 +174,7 @@ class Subscription(StripeObject):
     trial_end = models.DateTimeField(blank=True, null=True)
     trial_start = models.DateTimeField(blank=True, null=True)
 
-    @property
-    def stripe_subscription(self):
-        return stripe.Customer.retrieve(self.customer.stripe_id).subscriptions.retrieve(self.stripe_id)
+    objects = SubscriptionManager()
 
     @property
     def total_amount(self):

--- a/pinax/stripe/models.py
+++ b/pinax/stripe/models.py
@@ -160,7 +160,7 @@ class BitcoinReceiver(StripeObject):
 
 class Subscription(StripeObject):
 
-    customer = models.ForeignKey(Customer)
+    customer = models.ForeignKey(Customer, related_name="subscriptions")
     application_fee_percent = models.DecimalField(decimal_places=2, max_digits=3, default=None, null=True)
     cancel_at_period_end = models.BooleanField(default=False)
     canceled_at = models.DateTimeField(blank=True, null=True)


### PR DESCRIPTION
Am using pinax-stripe in our own app (with our own DRF views), and wanted to display the expiry date for a subscription within the app.  Added a few things to make this considerably more logical:

* Added related_name 'subscriptions' to Customer ForeignKey; allows easier reverse relation queries
* Adds a SubscriptionManager and a current_subscriptions() methods which can be used with the above, to allow something like the following:

```
def get_expiry_for_user(user):
    customer = customers.get_customer_for_user(user)
    if hasattr(customer, "subscriptions"):
        current_subscription = customer.subscriptions.current_subscriptions().last()
        if current_subscription:
            return current_subscription.current_period_end

get_expiry_for_user(self.request.user)
```

The code appears to currently allow multiple subscriptions for the same plan + user + valid period.  Should this be restricted?  (I'm happy to provide more PR's).