### PR TITLE
Added template tag to expose the Stripe public key.

### DIFF
--- a/docs/reference/templatetags.md
+++ b/docs/reference/templatetags.md
@@ -1,0 +1,25 @@
+# Template tags
+
+## stripe
+
+#### stripe_public_key
+
+Returns the value of the `PINAX_STRIPE_PUBLIC_KEY` setting as a Javascript
+single quoted string. This value can be used to initialize the Stripe
+Javascript library. For example:
+
+    {% load stripe %}
+    ...
+    <script>
+        Stripe.setPublishableKey({% stripe_public_key %});
+    </script>
+
+will generate:
+
+    <script>
+        Stripe.setPublishableKey('pk_<your public key here>');
+    </script>
+
+If `PINAX_STRIPE_PUBLIC_KEY` has not been defined, the value
+`*** PINAX_STRIPE_PUBLIC_KEY NOT SET ***` is returned **unquoted**. This
+will force a JavaScript syntax error to be raised wherever it has been used.

--- a/pinax/stripe/templatetags/stripe.py
+++ b/pinax/stripe/templatetags/stripe.py
@@ -1,0 +1,14 @@
+from django import template
+from django.conf import settings
+from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def stripe_public_key():
+    if settings.PINAX_STRIPE_PUBLIC_KEY:
+        return mark_safe("'%s'" % conditional_escape(settings.PINAX_STRIPE_PUBLIC_KEY))
+    else:
+        return "*** PINAX_STRIPE_PUBLIC_KEY NOT SET ***"

--- a/pinax/stripe/tests/test_templatetags.py
+++ b/pinax/stripe/tests/test_templatetags.py
@@ -1,0 +1,40 @@
+from django.test import TestCase, override_settings
+from django.template import Template, Context
+
+
+class TemplateTagTests(TestCase):
+
+    @override_settings(PINAX_STRIPE_PUBLIC_KEY='this-is-the-stripe-public-key')
+    def test_stripe_public_key(self):
+        self.maxDiff = None
+        template = Template("""{% load stripe %}
+            <script>
+                Stripe.setPublishableKey({% stripe_public_key %});
+            </script>
+            """)
+
+        self.assertEqual(
+            template.render(Context()),
+            """
+            <script>
+                Stripe.setPublishableKey('this-is-the-stripe-public-key');
+            </script>
+            """
+        )
+
+    def test_no_stripe_public_key(self):
+        self.maxDiff = None
+        template = Template("""{% load stripe %}
+            <script>
+                Stripe.setPublishableKey({% stripe_public_key %});
+            </script>
+            """)
+
+        self.assertEqual(
+            template.render(Context()),
+            """
+            <script>
+                Stripe.setPublishableKey(*** PINAX_STRIPE_PUBLIC_KEY NOT SET ***);
+            </script>
+            """
+        )


### PR DESCRIPTION
This adds an easy way to get the Stripe public key (the `PINAX_STRIPE_PUBLIC_KEY` settings) into a template so it can be used to configure the Stripe Javascript library.