### PR TITLE
Fixes #296 -- Ensure test users have an email address.

### DIFF
--- a/pinax/stripe/tests/test_email.py
+++ b/pinax/stripe/tests/test_email.py
@@ -15,7 +15,7 @@ class EmailReceiptTest(TestCase):
 
     def setUp(self):
         User = get_user_model()
-        self.user = User.objects.create_user(username="patrick")
+        self.user = User.objects.create_user(username="patrick", email="patrick@example.com")
         self.customer = Customer.objects.create(
             user=self.user,
             stripe_id="cus_xxxxxxxxxxxxxxx"


### PR DESCRIPTION
This was required due to a change in Django's development branch (django/django#88586314).