### PR TITLE
Added protection against creating duplicate customers.

### DIFF
--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -139,6 +139,36 @@ class CustomersTests(TestCase):
         self.assertIsNone(kwargs["trial_end"])
         self.assertTrue(SyncMock.called)
 
+    @patch("stripe.Customer.retrieve")
+    @patch("stripe.Customer.create")
+    def test_customer_create_user_duplicate(self, CreateMock, RetrieveMock):
+        # Create an existing database customer for this user
+        original = Customer.objects.create(user=self.user, stripe_id='cus_XXXXX')
+
+        new_customer = Mock()
+        RetrieveMock.return_value = new_customer
+
+        # customers.Create will return a new customer instance
+        CreateMock.return_value = dict(id="cus_YYYYY")
+        customer = customers.create(self.user)
+
+        # But only one customer will exist - the original one
+        self.assertEqual(Customer.objects.count(), 1)
+        self.assertEqual(customer.stripe_id, original.stripe_id)
+
+        # Check that the customer hasn't been modified
+        self.assertEqual(customer.user, self.user)
+        self.assertEqual(customer.stripe_id, "cus_XXXXX")
+        _, kwargs = CreateMock.call_args
+        self.assertEqual(kwargs["email"], self.user.email)
+        self.assertIsNone(kwargs["source"])
+        self.assertIsNone(kwargs["plan"])
+        self.assertIsNone(kwargs["trial_end"])
+
+        # But a customer *was* created, retrieved, and then disposed of.
+        RetrieveMock.assert_called_once_with("cus_YYYYY")
+        new_customer.delete.assert_called_once()
+
     @patch("pinax.stripe.actions.invoices.create_and_pay")
     @patch("pinax.stripe.actions.customers.sync_customer")
     @patch("stripe.Customer.create")


### PR DESCRIPTION
This can happen relatively easily if you put all stripe API calls into tasks. If you have two tasks which create the customer at the same time, you end up with an IntegrityError on one of the calls (because the OneToOne relation can't be formed), but two records in your Stripe account (because the stripe calls both succeed).