### PR TITLE
Limit installation requirement to jsonfield 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
       env: DJANGO=1.7 STRIPE=127
     - python: "3.5"
       env: DJANGO=1.7 STRIPE=128
+  allow_failures:
+    - env: DJANGO=master STRIPE=128
+    - env: DJANGO=master STRIPE=127
 install:
   - pip install tox coveralls
 script:

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     ],
     install_requires=[
         "django-appconf>=1.0.1",
-        "jsonfield>=1.0.3",
+        "jsonfield>=1.0.3,<2.0.0",
         "stripe>=1.7.9",
         "django>=1.7",
         "pytz",


### PR DESCRIPTION
Fixes #322 (failing CI builds on django 1.7).

~~Tests continue to fail because django-master is in the build matrix. See #310.~~ I've added the relevant excludes to the matrix in this PR, as that one also covers adding django 1.11.