### PR TITLE
Minor fix for the init_customers command

### DIFF
--- a/pinax/stripe/actions/invoices.py
+++ b/pinax/stripe/actions/invoices.py
@@ -37,8 +37,8 @@ def create_and_pay(customer):
     Returns:
         True, if invoice was created, False if there was an error
     """
-    invoice = create(customer)
     try:
+        invoice = create(customer)
         if invoice.amount_due > 0:
             invoice.pay()
         return True


### PR DESCRIPTION
Catch the `InvalidRequestError` during an init_customers call.

For an existing userbase, it was raising the following exception:

```sh
File "VENV/pinax/stripe/actions/customers.py", line 58, in create
  invoices.create_and_pay(cus)
File "VENV/pinax/stripe/actions/invoices.py", line 40, in create_and_pay
  invoice = create(customer)
File "VENV/pinax/stripe/actions/invoices.py", line 27, in create
  return stripe.Invoice.create(customer=customer.stripe_id)
File "VENV/stripe/resource.py", line 466, in create
  response, api_key = requestor.request('post', url, params, headers)
File "VENV/stripe/api_requestor.py", line 140, in request
  resp = self.interpret_response(rbody, rcode, rheaders)
File "VENV/stripe/api_requestor.py", line 288, in interpret_response
  self.handle_api_error(rbody, rcode, resp, rheaders)
File "VENV/stripe/api_requestor.py", line 159, in handle_api_error
  rbody, rcode, resp, rheaders)
stripe.error.InvalidRequestError: Request req_ABCDEFGH: Nothing to invoice for customer
```

I made this naive fix, which seems to have no side effect.

Cheers