### PR TITLE
Fix stripe.Customer.create() bug (quantity) in 3.4.0

### DIFF
--- a/pinax/stripe/actions/customers.py
+++ b/pinax/stripe/actions/customers.py
@@ -27,7 +27,7 @@ def can_charge(customer):
     return False
 
 
-def create(user, card=None, plan=settings.PINAX_STRIPE_DEFAULT_PLAN, charge_immediately=True, quantity=1):
+def create(user, card=None, plan=settings.PINAX_STRIPE_DEFAULT_PLAN, charge_immediately=True, quantity=None):
     """
     Creates a Stripe customer.
 
@@ -45,6 +45,9 @@ def create(user, card=None, plan=settings.PINAX_STRIPE_DEFAULT_PLAN, charge_imme
         the pinax.stripe.models.Customer object that was created
     """
     trial_end = hooks.hookset.trial_period(user, plan)
+
+    if plan and not quantity:
+        quantity = 1  # if there's a default plan, set a default quantity
 
     stripe_customer = stripe.Customer.create(
         email=user.email,

--- a/pinax/stripe/actions/customers.py
+++ b/pinax/stripe/actions/customers.py
@@ -46,9 +46,6 @@ def create(user, card=None, plan=settings.PINAX_STRIPE_DEFAULT_PLAN, charge_imme
     """
     trial_end = hooks.hookset.trial_period(user, plan)
 
-    if plan and not quantity:
-        quantity = 1  # if there's a default plan, set a default quantity
-
     stripe_customer = stripe.Customer.create(
         email=user.email,
         source=card,


### PR DESCRIPTION
3.4.0 introduced PR#319, which causes this error for some people now when trying to create/sync customers:

`InvalidRequestError: Request req_AV0P60vqXmdxUj: Received unknown parameter: quantity`

This appears to occur when a user doesn't have a DEFAULT_PLAN set in their settings.py (which is optional), and the app default for this is None.  Stripe's API (locked down to version 2015-10-16 by default in this project) does not allow a quantity to be set without a plan.

This changes the default for 'quantity' to None, which makes it behave correctly.  The API sets this to '1' by default anyway if a plan is specified with no quantity according to https://web.archive.org/web/20150619020503/https://stripe.com/docs/api#create_customer)

(As an aside, the current version of the API doesn't support any of these parameters - subscriptions are dealt with entirely separately to customers - would you accept a seperate PR to this retargeting the app towards the current Stripe API?)