### PR TITLE
Remove redundant transaction in customers.create

### DIFF
--- a/pinax/stripe/actions/customers.py
+++ b/pinax/stripe/actions/customers.py
@@ -1,4 +1,3 @@
-from django.db import IntegrityError, transaction
 from django.utils import timezone
 from django.utils.encoding import smart_str
 
@@ -45,7 +44,6 @@ def create(user, card=None, plan=settings.PINAX_STRIPE_DEFAULT_PLAN, charge_imme
         the pinax.stripe.models.Customer object that was created
     """
     trial_end = hooks.hookset.trial_period(user, plan)
-
     stripe_customer = stripe.Customer.create(
         email=user.email,
         source=card,
@@ -53,21 +51,19 @@ def create(user, card=None, plan=settings.PINAX_STRIPE_DEFAULT_PLAN, charge_imme
         quantity=quantity,
         trial_end=trial_end
     )
-    try:
-        with transaction.atomic():
-            cus = models.Customer.objects.create(
-                user=user,
-                stripe_id=stripe_customer["id"]
-            )
-    except IntegrityError:
-        # There is already a Customer object for this user
+    cus, created = models.Customer.objects.get_or_create(
+        user=user,
+        defaults={
+            "stripe_id": stripe_customer["id"]
+        }
+    )
+    if created:
+        sync_customer(cus, stripe_customer)
+        if plan and charge_immediately:
+            invoices.create_and_pay(cus)
+    else:
+        # remove this extra customer as it is not needed
         stripe.Customer.retrieve(stripe_customer["id"]).delete()
-        return models.Customer.objects.get(user=user)
-
-    sync_customer(cus, stripe_customer)
-
-    if plan and charge_immediately:
-        invoices.create_and_pay(cus)
     return cus
 
 

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -150,6 +150,7 @@ class CustomersTests(TestCase):
 
         # customers.Create will return a new customer instance
         CreateMock.return_value = dict(id="cus_YYYYY")
+
         customer = customers.create(self.user)
 
         # But only one customer will exist - the original one


### PR DESCRIPTION
The use of transaction.atomic() wrapping the Customer.objects.create call is redundant as there is only a single query which will either succeed or fail. If a customer already exists, an IntegrityError will still be raised.