### PR TITLE
Adds webhooks for plans

### DIFF
--- a/pinax/stripe/actions/plans.py
+++ b/pinax/stripe/actions/plans.py
@@ -29,3 +29,30 @@ def sync_plans():
             defaults=defaults
         )
         utils.update_with_defaults(obj, defaults, created)
+
+
+def sync_plan(plan, event=None):
+    """
+    Syncronizes a plan from the Stripe API
+
+    Args:
+        plan: data from Stripe API representing a plan
+        event: the event associated with the plan
+    """
+
+    defaults = {
+        "amount": utils.convert_amount_for_db(plan["amount"], plan["currency"]),
+        "currency": plan["currency"] or "",
+        "interval": plan["interval"],
+        "interval_count": plan["interval_count"],
+        "name": plan["name"],
+        "statement_descriptor": plan["statement_descriptor"] or "",
+        "trial_period_days": plan["trial_period_days"],
+        "metadata": plan["metadata"]
+    }
+
+    obj, created = models.Plan.objects.get_or_create(
+        stripe_id=plan["id"],
+        defaults=defaults
+    )
+    utils.update_with_defaults(obj, defaults, created)

--- a/pinax/stripe/tests/__init__.py
+++ b/pinax/stripe/tests/__init__.py
@@ -123,3 +123,33 @@ TRANSFER_PENDING_TEST_DATA = {
     "request": None,
     "type": "transfer.created"
 }
+
+PLAN_CREATED_TEST_DATA = {
+    "data": {
+        "previous_attributes": {
+            "name": "Old name"
+        },
+        "object": {
+            "interval": "month",
+            "amount": 50,
+            "id": "gold1",
+            "trial_period_days": None,
+            "livemode": True,
+            "statement_descriptor": None,
+            "interval_count": 1,
+            "object": "plan",
+            "currency": "usd",
+            "created": 1498573686,
+            "name": "Pro Plan",
+            "metadata": {}
+        }
+    },
+    "type": "plan.updated",
+    "request": None,
+    "api_version": "2017-06-05",
+    "object": "event",
+    "id": "evt_00000000000000",
+    "livemode": True,
+    "pending_webhooks": 1,
+    "created": 1326853478
+}

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -844,6 +844,35 @@ class SyncsTests(TestCase):
         plans.sync_plans()
         self.assertEquals(Plan.objects.get(stripe_id="simple1").amount, decimal.Decimal("4.99"))
 
+    def test_sync_plan(self):
+        """
+        Test that a single Plan is updated
+        """
+        Plan.objects.create(
+            stripe_id="pro2",
+            name="Plan Plan",
+            interval="month",
+            interval_count=1,
+            amount=decimal.Decimal("19.99")
+        )
+        plan = {
+            "id": "pro2",
+            "object": "plan",
+            "amount": 1999,
+            "created": 1448121054,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": False,
+            "metadata": {},
+            "name": "Gold Plan",
+            "statement_descriptor": "ALTMAN",
+            "trial_period_days": 3
+        }
+        plans.sync_plan(plan)
+        self.assertTrue(Plan.objects.all().count(), 1)
+        self.assertEquals(Plan.objects.get(stripe_id="pro2").name, plan["name"])
+
     def test_sync_payment_source_from_stripe_data_card(self):
         source = {
             "id": "card_17AMEBI10iPhvocM1LnJ0dBc",

--- a/pinax/stripe/tests/test_webhooks.py
+++ b/pinax/stripe/tests/test_webhooks.py
@@ -16,9 +16,19 @@ import stripe
 
 from mock import patch
 
-from . import TRANSFER_CREATED_TEST_DATA, TRANSFER_PENDING_TEST_DATA
-from ..models import Event, Transfer, EventProcessingException, Customer
-from ..webhooks import registry, AccountUpdatedWebhook, ChargeCapturedWebhook, CustomerUpdatedWebhook, CustomerSourceCreatedWebhook, CustomerSourceDeletedWebhook, CustomerSubscriptionCreatedWebhook, InvoiceCreatedWebhook
+from . import TRANSFER_CREATED_TEST_DATA, TRANSFER_PENDING_TEST_DATA, PLAN_CREATED_TEST_DATA
+from ..models import Event, Transfer, EventProcessingException, Customer, Plan
+from ..webhooks import (
+    registry,
+    AccountUpdatedWebhook,
+    ChargeCapturedWebhook,
+    CustomerUpdatedWebhook,
+    CustomerSourceCreatedWebhook,
+    CustomerSourceDeletedWebhook,
+    CustomerSubscriptionCreatedWebhook,
+    InvoiceCreatedWebhook,
+    PlanUpdatedWebhook
+)
 
 
 class WebhookRegistryTest(TestCase):
@@ -180,6 +190,50 @@ class CustomerSourceDeletedWebhookTest(TestCase):
         event.validated_message = dict(data=dict(object=dict(id=1)))
         CustomerSourceDeletedWebhook(event).process_webhook()
         self.assertTrue(SyncMock.called)
+
+
+class PlanCreatedWebhookTest(TestCase):
+
+    @patch("stripe.Event.retrieve")
+    def test_plan_created(self, EventMock):
+        ev = EventMock()
+        ev.to_dict.return_value = PLAN_CREATED_TEST_DATA
+        event = Event.objects.create(
+            stripe_id=PLAN_CREATED_TEST_DATA["id"],
+            kind="plan.created",
+            livemode=True,
+            webhook_message=PLAN_CREATED_TEST_DATA,
+            validated_message=PLAN_CREATED_TEST_DATA,
+            valid=True
+        )
+        registry.get(event.kind)(event).process()
+        self.assertEquals(Plan.objects.all().count(), 1)
+
+
+class PlanUpdatedWebhookTest(TestCase):
+
+    @patch("stripe.Event.retrieve")
+    def test_plan_created(self, EventMock):
+        Plan.objects.create(
+            stripe_id="gold1",
+            name="Gold Plan",
+            interval="month",
+            interval_count=1,
+            amount=decimal.Decimal("9.99")
+        )
+        ev = EventMock()
+        ev.to_dict.return_value = PLAN_CREATED_TEST_DATA
+        event = Event.objects.create(
+            stripe_id=PLAN_CREATED_TEST_DATA["id"],
+            kind="plan.updated",
+            livemode=True,
+            webhook_message=PLAN_CREATED_TEST_DATA,
+            validated_message=PLAN_CREATED_TEST_DATA,
+            valid=True
+        )
+        registry.get(event.kind)(event).process()
+        plan = Plan.objects.get(stripe_id="gold1")
+        self.assertEquals(plan.name, PLAN_CREATED_TEST_DATA["data"]["object"]["name"])
 
 
 class CustomerSubscriptionCreatedWebhookTest(TestCase):

--- a/pinax/stripe/tests/test_webhooks.py
+++ b/pinax/stripe/tests/test_webhooks.py
@@ -26,8 +26,7 @@ from ..webhooks import (
     CustomerSourceCreatedWebhook,
     CustomerSourceDeletedWebhook,
     CustomerSubscriptionCreatedWebhook,
-    InvoiceCreatedWebhook,
-    PlanUpdatedWebhook
+    InvoiceCreatedWebhook
 )
 
 

--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -6,7 +6,7 @@ import stripe
 
 from six import with_metaclass
 
-from .actions import charges, customers, exceptions, invoices, transfers, sources, subscriptions
+from .actions import charges, customers, exceptions, invoices, plans, transfers, sources, subscriptions
 from .conf import settings
 
 
@@ -397,7 +397,13 @@ class OrderUpdatedWebhook(Webhook):
     description = "Occurs whenever an order is updated."
 
 
-class PlanCreatedWebhook(Webhook):
+class PlanWebhook(Webhook):
+
+    def process_webhook(self):
+        plans.sync_plan(self.event.message["data"]["object"], self.event)
+
+
+class PlanCreatedWebhook(PlanWebhook):
     name = "plan.created"
     description = "Occurs whenever a plan is created."
 
@@ -407,7 +413,7 @@ class PlanDeletedWebhook(Webhook):
     description = "Occurs whenever a plan is deleted."
 
 
-class PlanUpdatedWebhook(Webhook):
+class PlanUpdatedWebhook(PlanWebhook):
     name = "plan.updated"
     description = "Occurs whenever a plan is updated."
 


### PR DESCRIPTION
Adds webhooks to update and create plans that are created in Stripe.

* Adds webhooks for PlanUpdated and PlanCreated
* Adds a method to sync a plan by stripe id
* Adds plan action tests to test updates to a plan
* Adds webhook tests for PlanUpdatedWebhook and PlanCreatedWebhook

Issues: #276