### PR TITLE
Show last 4 digits of card in notification

### DIFF
--- a/pinax/stripe/models.py
+++ b/pinax/stripe/models.py
@@ -303,3 +303,7 @@ class Charge(StripeObject):
     @property
     def stripe_charge(self):
         return stripe.Charge.retrieve(self.stripe_id)
+
+    @property
+    def card(self):
+        return Card.objects.filter(stripe_id=self.source).first()

--- a/pinax/stripe/templates/pinax/stripe/email/body_base.txt
+++ b/pinax/stripe/templates/pinax/stripe/email/body_base.txt
@@ -1,4 +1,4 @@
-{% if charge.paid %}Your {{ site.name }} account was successfully charged ${{ charge.amount|floatformat:2 }} to the credit card ending in {{ charge.card_last_4 }}. The invoice below is for your records.
+{% if charge.paid %}Your {{ site.name }} account was successfully charged ${{ charge.amount|floatformat:2 }} to the credit card ending in {{ charge.card.last4 }}. The invoice below is for your records.
 
 
 ========================================================
@@ -16,8 +16,8 @@ DETAILS
 TOTAL: ${{ charge.amount|floatformat:2 }} USD
 PAID BY CREDIT CARD: -${{ charge.amount|floatformat:2 }}
 ========================================================
-{% else %}{% if charge.refunded %}Your credit card ending in {{ charge.card_last_4 }} was refunded ${{ charge.amount|floatformat:2 }}.
-{% else %}We are sorry, but we failed to charge your credit card ending in {{ charge.card_last_4 }} for the amount ${{ charge.amount|floatformat:2 }}.
+{% else %}{% if charge.refunded %}Your credit card ending in {{ charge.card.last4 }} was refunded ${{ charge.amount|floatformat:2 }}.
+{% else %}We are sorry, but we failed to charge your credit card ending in {{ charge.card.last4 }} for the amount ${{ charge.amount|floatformat:2 }}.
 {% endif %}{% endif %}
 
 Please contact us with any questions regarding this invoice.


### PR DESCRIPTION
Properly show the last four digits of the credit card charged in the email notification.

* Updated notification template
* Added a property on the Card model

Issues: #260