### PR TITLE
Better handling of syncing deleted customers

### DIFF
--- a/pinax/stripe/actions/customers.py
+++ b/pinax/stripe/actions/customers.py
@@ -84,6 +84,12 @@ def get_customer_for_user(user):
     return next(iter(models.Customer.objects.filter(user=user)), None)
 
 
+def purge_local(customer):
+    customer.user = None
+    customer.date_purged = timezone.now()
+    customer.save()
+
+
 def purge(customer):
     """
     Deletes the Stripe customer data and purges the linking of the transaction
@@ -99,9 +105,7 @@ def purge(customer):
             # The exception was thrown because the customer was already
             # deleted on the stripe side, ignore the exception
             raise
-    customer.user = None
-    customer.date_purged = timezone.now()
-    customer.save()
+    purge_local(customer)
 
 
 def link_customer(event):
@@ -151,8 +155,16 @@ def sync_customer(customer, cu=None):
         customer: a Customer object
         cu: optionally, data from the Stripe API representing the customer
     """
+    if customer.date_purged is not None:
+        return
+
     if cu is None:
         cu = customer.stripe_customer
+
+    if cu.get('deleted', False):
+        purge_local(customer)
+        return
+
     customer.account_balance = utils.convert_amount_for_db(cu["account_balance"], cu["currency"])
     customer.currency = cu["currency"] or ""
     customer.delinquent = cu["delinquent"]

--- a/pinax/stripe/management/commands/sync_customers.py
+++ b/pinax/stripe/management/commands/sync_customers.py
@@ -31,5 +31,6 @@ class Command(BaseCommand):
                     # This user doesn't exist (might be in test mode)
                     continue
 
-            invoices.sync_invoices_for_customer(customer)
-            charges.sync_charges_for_customer(customer)
+            if customer.date_purged is None:
+                invoices.sync_invoices_for_customer(customer)
+                charges.sync_charges_for_customer(customer)

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -1175,6 +1175,31 @@ class SyncsTests(TestCase):
         self.assertTrue(SyncPaymentSourceMock.called)
         self.assertTrue(SyncSubscriptionMock.called)
 
+    @patch("pinax.stripe.actions.customers.purge_local")
+    @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
+    @patch("pinax.stripe.actions.sources.sync_payment_source_from_stripe_data")
+    @patch("stripe.Customer.retrieve")
+    def test_sync_customer_purged_locally(self, RetrieveMock, SyncPaymentSourceMock, SyncSubscriptionMock, PurgeLocalMock):
+        self.customer.date_purged = timezone.now()
+        customers.sync_customer(self.customer)
+        self.assertFalse(RetrieveMock.called)
+        self.assertFalse(SyncPaymentSourceMock.called)
+        self.assertFalse(SyncSubscriptionMock.called)
+        self.assertFalse(PurgeLocalMock.called)
+
+    @patch("pinax.stripe.actions.customers.purge_local")
+    @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
+    @patch("pinax.stripe.actions.sources.sync_payment_source_from_stripe_data")
+    @patch("stripe.Customer.retrieve")
+    def test_sync_customer_purged_remotely_not_locally(self, RetrieveMock, SyncPaymentSourceMock, SyncSubscriptionMock, PurgeLocalMock):
+        RetrieveMock.return_value = dict(
+            deleted=True
+        )
+        customers.sync_customer(self.customer)
+        self.assertFalse(SyncPaymentSourceMock.called)
+        self.assertFalse(SyncSubscriptionMock.called)
+        self.assertTrue(PurgeLocalMock.called)
+
     @patch("pinax.stripe.actions.invoices.sync_invoice_from_stripe_data")
     @patch("stripe.Customer.retrieve")
     def test_sync_invoices_for_customer(self, RetreiveMock, SyncMock):

--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -247,7 +247,7 @@ class CustomerDeletedWebhook(Webhook):
     description = "Occurs whenever a customer is deleted."
 
     def process_webhook(self):
-        customers.purge(self.event.customer)
+        customers.purge_local(self.event.customer)
 
 
 class CustomerUpdatedWebhook(Webhook):


### PR DESCRIPTION
Credit to @tasn for work done in PR #325 - this PR adds tests

Fixes #268

#### What's this PR do?

Modifies deleted customer webhook to purge customer locally and not attempt to delete customer again on Stripe.

Modifies customer syncing actions and management command to handle situation where customer is deleted remotely but not locally.

#### Any background context you want to provide?

#### What ticket or issue # does this fix?

Closes #268 

#### Definition of Done (check if considered and/or addressed):

- [ ] Are all backwards incompatible changes documented in this PR?
- [ ] Have all new dependencies been documented in this PR?
- [ ] Has the appropriate documentation been updated (if applicable)?
- [x ] Have you written tests to prove this change works (if applicable)?
