### PR TITLE
[RFC] admin: prefetch related fields

### DIFF
--- a/pinax/stripe/tests/test_admin.py
+++ b/pinax/stripe/tests/test_admin.py
@@ -1,5 +1,6 @@
 import datetime
 
+import django
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.utils import timezone
@@ -99,8 +100,16 @@ class AdminTestCase(TestCase):
     def test_customer_admin(self):
         """Make sure we get good responses for all filter options"""
         url = reverse("admin:pinax_stripe_customer_changelist")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+
+        # Django 1.10 has the following query twice:
+        # SELECT COUNT(*) AS "__count" FROM "pinax_stripe_customer"
+        # (since https://github.com/django/django/commit/5fa7b592b3f)
+        # We might want to test for "num < 10" here instead, and/or compare the
+        # number to be equal with X and X+1 customers
+        num = 8 if django.VERSION >= (1, 10) else 7
+        with self.assertNumQueries(num):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
 
         response = self.client.get(url + "?sub_status=active")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This only does it for the customer's changelist view now, but it meant
to be generic enough for other admins.

You can easily see the number of queries going down when using django-debug-toolbar or something similar.

TODO:
 - [x] tests