### PR TITLE
Fixed a bug where if a subscription had a trial end of none, that the…

### DIFF
--- a/pinax/stripe/actions/subscriptions.py
+++ b/pinax/stripe/actions/subscriptions.py
@@ -193,7 +193,8 @@ def update(subscription, plan=None, quantity=None, prorate=True, coupon=None, ch
     if coupon:
         stripe_subscription.coupon = coupon
     if charge_immediately:
-        if utils.convert_tstamp(stripe_subscription.trial_end) > timezone.now():
+        if stripe_subscription.trial_end is not None and \
+            utils.convert_tstamp(stripe_subscription.trial_end) > timezone.now():
             stripe_subscription.trial_end = 'now'
     sub = stripe_subscription.save()
     customer = models.Customer.objects.get(pk=subscription.customer.pk)


### PR DESCRIPTION
Update subscription code would crash on charge_immediately when trial_period was set to NULL in database (None).  This would happen if there were plans with trial periods mixed with plans that do not have trial periods.

#### What's this PR do?
Makes sure the trial period is not 'None' before attempting a time comparison between trial_end and timezone.now()

#### Any background context you want to provide?
This happens when you try to 'charge_immediately' on a plan with no trial period, or no trial period plan was initially selected.

#### What ticket or issue # does this fix?
n/a

Closes

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [x] Has the appropriate documentation been updated (if applicable)?
- [x] Have you written tests to prove this change works (if applicable)?
