### PR TITLE
CustomerUpdatedWebhook: use provided customer object from the event

### DIFF
--- a/pinax/stripe/actions/customers.py
+++ b/pinax/stripe/actions/customers.py
@@ -145,7 +145,7 @@ def set_default_source(customer, source):
 
 def sync_customer(customer, cu=None):
     """
-    Syncronizes a local Customer object with details from the Stripe API
+    Synchronizes a local Customer object with details from the Stripe API
 
     Args:
         customer: a Customer object

--- a/pinax/stripe/tests/test_webhooks.py
+++ b/pinax/stripe/tests/test_webhooks.py
@@ -168,7 +168,18 @@ class CustomerUpdatedWebhookTest(TestCase):
     def test_process_webhook(self, SyncMock):
         event = Event.objects.create(kind=CustomerUpdatedWebhook.name, webhook_message={}, valid=True, processed=False)
         CustomerUpdatedWebhook(event).process_webhook()
-        self.assertTrue(SyncMock.called)
+        self.assertEquals(SyncMock.call_count, 1)
+        self.assertEquals(SyncMock.call_args[0], (None, None))
+
+    @patch("pinax.stripe.actions.customers.sync_customer")
+    def test_process_webhook_with_data(self, SyncMock):
+        event = Event.objects.create(kind=CustomerUpdatedWebhook.name, webhook_message={}, valid=True, processed=False)
+        obj = object()
+        event.validated_message = dict(data=dict(object=obj))
+        CustomerUpdatedWebhook(event).process_webhook()
+        self.assertEquals(SyncMock.call_count, 1)
+        self.assertIsNone(SyncMock.call_args[0][0])
+        self.assertIs(SyncMock.call_args[0][1], obj)
 
 
 class CustomerSourceCreatedWebhookTest(TestCase):

--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -255,7 +255,12 @@ class CustomerUpdatedWebhook(Webhook):
     description = "Occurs whenever any property of a customer changes."
 
     def process_webhook(self):
-        customers.sync_customer(self.event.customer)
+        cu = None
+        try:
+            cu = self.event.message["data"]["object"]
+        except (KeyError, TypeError):
+            pass
+        customers.sync_customer(self.event.customer, cu)
 
 
 class CustomerDiscountCreatedWebhook(Webhook):


### PR DESCRIPTION
It saves a network roundtrip, and might even be necessary if events are supposed to be processed in order.

TODO:
- [x] tests?!