### PR TITLE
tests: move MockView directly into urls module

### DIFF
--- a/pinax/stripe/tests/mock_views.py
+++ b/pinax/stripe/tests/mock_views.py
@@ -1,8 +1,0 @@
-from django.http import HttpResponse
-from django.views.generic import View
-
-
-class MockView(View):
-
-    def get(self, request, *args, **kwargs):
-        return HttpResponse("Hello, World!")

--- a/pinax/stripe/tests/urls.py
+++ b/pinax/stripe/tests/urls.py
@@ -1,25 +1,17 @@
 from django.contrib import admin
 from django.conf.urls import url
-from .mock_views import MockView
 from ..urls import urlpatterns
 
+
+class FakeViewForUrl(object):
+    def __call__(self):
+        raise Exception("Should not get called.")
+
+
 urlpatterns += [
-
     url(r"^admin/", admin.site.urls),
-
-    url(
-        r"^the/app/$",
-        MockView.as_view(),
-        name="the_app"
-    ),
-    url(
-        r"^accounts/signup/$",
-        MockView.as_view(),
-        name="signup"
-    ),
-    url(
-        r"^password/reset/confirm/(?P<token>.+)/$",
-        MockView.as_view(),
-        name="password_reset"
-    ),
+    url(r"^the/app/$", FakeViewForUrl, name="the_app"),
+    url(r"^accounts/signup/$", FakeViewForUrl, name="signup"),
+    url(r"^password/reset/confirm/(?P<token>.+)/$", FakeViewForUrl,
+        name="password_reset"),
 ]


### PR DESCRIPTION
It is only uses to create the URLs, for testing the middleware against
it.