### PR TITLE
Add __repr__ methods

### DIFF
--- a/pinax/stripe/models.py
+++ b/pinax/stripe/models.py
@@ -47,6 +47,18 @@ class Plan(AccountRelatedStripeObject):
     def __str__(self):
         return "{} ({}{})".format(self.name, CURRENCY_SYMBOLS.get(self.currency, ""), self.amount)
 
+    def __repr__(self):
+        return "Plan(pk={!r}, name={!r}, amount={!r}, currency={!r}, interval={!r}, interval_count={!r}, trial_period_days={!r}, stripe_id={!r})".format(
+            self.pk,
+            str(self.name),
+            self.amount,
+            str(self.currency),
+            str(self.interval),
+            self.interval_count,
+            self.trial_period_days,
+            str(self.stripe_id),
+        )
+
 
 @python_2_unicode_compatible
 class Coupon(StripeObject):
@@ -178,6 +190,13 @@ class Customer(AccountRelatedStripeObject):
     def __str__(self):
         return str(self.user)
 
+    def __repr__(self):
+        return "Customer(pk={!r}, user={!r}, stripe_id={!r})".format(
+            self.pk,
+            self.user,
+            str(self.stripe_id),
+        )
+
 
 class Card(StripeObject):
 
@@ -265,6 +284,15 @@ class Subscription(StripeObject):
         self.status = None
         self.quantity = 0
         self.amount = 0
+
+    def __repr__(self):
+        return "Subscription(pk={!r}, customer={!r}, plan={!r}, status={!r}, stripe_id={!r})".format(
+            self.pk,
+            self.customer if hasattr(self, "customer") else None,
+            self.plan if hasattr(self, "plan") else None,
+            str(self.status),
+            str(self.stripe_id),
+        )
 
 
 class Invoice(StripeObject):
@@ -376,6 +404,7 @@ class Charge(StripeObject):
         return Card.objects.filter(stripe_id=self.source).first()
 
 
+@python_2_unicode_compatible
 class Account(StripeObject):
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)
@@ -390,7 +419,7 @@ class Account(StripeObject):
     decline_charge_on_cvc_failure = models.BooleanField(default=False)
     default_currency = models.CharField(max_length=3)
     details_submitted = models.BooleanField(default=False)
-    display_name = models.TextField(blank=True, null=True)
+    display_name = models.TextField(blank=False, null=False)
     email = models.TextField(blank=True, null=True)
 
     legal_entity_address_city = models.TextField(null=True, blank=True)
@@ -446,6 +475,17 @@ class Account(StripeObject):
     @property
     def stripe_account(self):
         return stripe.Account.retrieve(self.stripe_id)
+
+    def __str__(self):
+        return "{} - {}".format(self.display_name, self.stripe_id)
+
+    def __repr__(self):
+        return "Account(pk={!r}, display_name={!r}, type={!r}, stripe_id={!r})".format(
+            self.pk,
+            str(self.display_name),
+            self.type,
+            str(self.stripe_id),
+        )
 
 
 class BankAccount(StripeObject):

--- a/pinax/stripe/tests/test_models.py
+++ b/pinax/stripe/tests/test_models.py
@@ -46,6 +46,10 @@ class ModelTests(TestCase):
         p = Plan(amount=decimal.Decimal("5"), name="My Plan", currency="jpy", interval="monthly", interval_count=1)
         self.assertTrue(u"\u00a5" in _str(p))
 
+    def test_plan_repl(self):
+        p = Plan(amount=decimal.Decimal("5"), name="My Plan", interval="monthly", interval_count=1)
+        self.assertEquals(repr(p), "Plan(pk=None, name='My Plan', amount=Decimal('5'), currency='', interval='monthly', interval_count=1, trial_period_days=None, stripe_id='')")
+
     def test_event_processing_exception_str(self):
         e = EventProcessingException(data="hello", message="hi there", traceback="fake")
         self.assertTrue("Event=" in str(e))
@@ -57,6 +61,10 @@ class ModelTests(TestCase):
     def test_customer_str(self):
         e = Customer()
         self.assertTrue("None" in str(e))
+
+    def test_customer_repl(self):
+        c = Customer()
+        self.assertEquals(repr(c), "Customer(pk=None, user=None, stripe_id='')")
 
     def test_plan_display_invoiceitem(self):
         p = Plan(amount=decimal.Decimal("5"), name="My Plan", interval="monthly", interval_count=1)
@@ -85,6 +93,20 @@ class ModelTests(TestCase):
     def test_invoice_status_not_paid(self):
         self.assertEquals(Invoice(paid=False).status, "Open")
 
+    def test_subscription_repr(self):
+        s = Subscription()
+        self.assertEquals(repr(s), "Subscription(pk=None, customer=None, plan=None, status='', stripe_id='')")
+        s.customer = Customer()
+        s.plan = Plan()
+        s.status = "active"
+        s.stripe_id = "sub_X"
+        self.assertEquals(
+            repr(s),
+            "Subscription(pk=None, customer={!r}, plan={!r}, status='active', stripe_id='sub_X')".format(
+                s.customer,
+                s.plan,
+            ))
+
     def test_subscription_total_amount(self):
         sub = Subscription(plan=Plan(name="Pro Plan", amount=decimal.Decimal("100")), quantity=2)
         self.assertEquals(sub.total_amount, decimal.Decimal("200"))
@@ -105,6 +127,17 @@ class ModelTests(TestCase):
         self.assertIsNone(sub.status)
         self.assertEquals(sub.quantity, 0)
         self.assertEquals(sub.amount, 0)
+
+    def test_account_str_and_repr(self):
+        a = Account()
+        self.assertEquals(str(a), " - ")
+        self.assertEquals(repr(a), "Account(pk=None, display_name='', type=None, stripe_id='')")
+        a.stripe_id = "acct_X"
+        self.assertEquals(str(a), " - acct_X")
+        self.assertEquals(repr(a), "Account(pk=None, display_name='', type=None, stripe_id='acct_X')")
+        a.display_name = "Display name"
+        self.assertEquals(str(a), "Display name - acct_X")
+        self.assertEquals(repr(a), "Account(pk=None, display_name='Display name', type=None, stripe_id='acct_X')")
 
 
 class StripeObjectTests(TestCase):


### PR DESCRIPTION
This is only done for Plan, Customer and Subscription for now, and open
for discussion.

It helps a lot when debugging and/or looking at locals in tracebacks.

TODO:
- [x] tests