### PR TITLE
Re-add tox to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,39 @@ multi_line_output=3
 known_django=django
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
+[tox]
+envlist =
+    checkqa
+    py27-dj{17,18,19,110,111}-stripe{127,128}
+    py33-dj{17,18}-stripe{127,128}
+    py34-dj{17,18,19,110,111,master}-stripe{127,128}
+    py35-dj{18,19,110,111,master}-stripe{127,128}
+    py36-dj{111,master}-stripe{127,128}
+
+[testenv]
+deps =
+    py{27,33,34,35,36}: coverage == 4.4.1
+    stripe127: stripe<1.28.0
+    stripe128: stripe>=1.28.0
+    dj17: Django>=1.7,<1.8
+    dj18: Django>=1.8,<1.9
+    dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11a1,<2.0
+    master: https://github.com/django/django/tarball/master
+usedevelop = True
+setenv =
+   LANG=en_US.UTF-8
+   LANGUAGE=en_US:en
+   LC_ALL=en_US.UTF-8
+commands =
+    coverage run setup.py test {posargs}
+    coverage report -m --skip-covered
+
+[testenv:checkqa]
+basepython = python3.6
+commands =
+    flake8 --inline-quotes "double" pinax
+deps =
+    flake8 == 2.5.4
+    flake8-quotes == 0.11.0


### PR DESCRIPTION
It seems to have been accidentally removed in d4fb476 when moving to
CircleCI, which does not use tox - but tox is especially useful during
development, so let's keep it.