### PR TITLE
subscriptions.create: use customer's stripe_id

### DIFF
--- a/pinax/stripe/actions/subscriptions.py
+++ b/pinax/stripe/actions/subscriptions.py
@@ -40,7 +40,6 @@ def create(customer, plan, quantity=None, trial_days=None, token=None, coupon=No
         the data representing the subscription object that was created
     """
     quantity = hooks.hookset.adjust_subscription_quantity(customer=customer, plan=plan, quantity=quantity)
-    cu = customer.stripe_customer
 
     subscription_params = {}
     if trial_days:
@@ -48,11 +47,12 @@ def create(customer, plan, quantity=None, trial_days=None, token=None, coupon=No
     if token:
         subscription_params["source"] = token
 
+    subscription_params["customer"] = customer.stripe_id
     subscription_params["plan"] = plan
     subscription_params["quantity"] = quantity
     subscription_params["coupon"] = coupon
     subscription_params["tax_percent"] = tax_percent
-    resp = cu.subscriptions.create(**subscription_params)
+    resp = stripe.Subscription.create(**subscription_params)
 
     return sync_subscription_from_stripe_data(customer, resp)
 

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -755,32 +755,27 @@ class SubscriptionsTests(TestCase):
         self.assertTrue(SubMock.stripe_subscription.save.called)
         self.assertTrue(SyncMock.called)
 
-    @patch("stripe.Customer.retrieve")
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
-    def test_subscription_create(self, SyncMock, CustomerMock):
+    @patch("stripe.Subscription.create")
+    def test_subscription_create(self, SubscriptionCreateMock, SyncMock):
         subscriptions.create(self.customer, "the-plan")
-        sub_create = CustomerMock().subscriptions.create
-        self.assertTrue(sub_create.called)
         self.assertTrue(SyncMock.called)
+        self.assertTrue(SubscriptionCreateMock.called)
 
-    @patch("stripe.Customer.retrieve")
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
-    def test_subscription_create_with_trial(self, SyncMock, CustomerMock):
+    @patch("stripe.Subscription.create")
+    def test_subscription_create_with_trial(self, SubscriptionCreateMock, SyncMock):
         subscriptions.create(self.customer, "the-plan", trial_days=3)
-        sub_create = CustomerMock().subscriptions.create
-        self.assertTrue(sub_create.called)
-        self.assertTrue(SyncMock.called)
-        _, kwargs = sub_create.call_args
+        self.assertTrue(SubscriptionCreateMock.called)
+        _, kwargs = SubscriptionCreateMock.call_args
         self.assertEquals(kwargs["trial_end"].date(), (datetime.datetime.utcnow() + datetime.timedelta(days=3)).date())
 
-    @patch("stripe.Customer.retrieve")
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
-    def test_subscription_create_token(self, SyncMock, CustomerMock):
-        sub_create = CustomerMock().subscriptions.create
+    @patch("stripe.Subscription.create")
+    def test_subscription_create_token(self, SubscriptionCreateMock, CustomerMock):
         subscriptions.create(self.customer, "the-plan", token="token")
-        self.assertTrue(sub_create.called)
-        self.assertTrue(SyncMock.called)
-        _, kwargs = sub_create.call_args
+        self.assertTrue(SubscriptionCreateMock.called)
+        _, kwargs = SubscriptionCreateMock.call_args
         self.assertEquals(kwargs["source"], "token")
 
     def test_is_period_current(self):


### PR DESCRIPTION
This avoids having to mock fetching the customer in tests, and should be better in general.

Needs test adjustments in case this makes sense.