### PR TITLE
Prevent creation of disposable Customers

### DIFF
--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -268,10 +268,6 @@ class CustomersTests(TestCase):
 
         new_customer = Mock()
         RetrieveMock.return_value = new_customer
-
-        # customers.Create will return a new customer instance
-        CreateMock.return_value = dict(id="cus_YYYYY")
-
         customer = customers.create(self.user)
 
         # But only one customer will exist - the original one
@@ -281,15 +277,44 @@ class CustomersTests(TestCase):
         # Check that the customer hasn't been modified
         self.assertEqual(customer.user, self.user)
         self.assertEqual(customer.stripe_id, "cus_XXXXX")
+        CreateMock.assert_not_called()
+
+    @patch("stripe.Customer.retrieve")
+    @patch("stripe.Customer.create")
+    def test_customer_create_local_customer_but_no_remote(self, CreateMock, RetrieveMock):
+        # Create an existing database customer for this user
+        Customer.objects.create(user=self.user, stripe_id="cus_XXXXX")
+
+        RetrieveMock.side_effect = stripe.error.InvalidRequestError(
+            message="invalid", param=None)
+
+        # customers.Create will return a new customer instance
+        CreateMock.return_value = {
+            "id": "cus_YYYYY",
+            "account_balance": 0,
+            "currency": "us",
+            "delinquent": False,
+            "default_source": "",
+            "sources": {"data": []},
+            "subscriptions": {"data": []},
+        }
+        customer = customers.create(self.user)
+
+        # But a customer *was* retrieved, but not found
+        RetrieveMock.assert_called_once_with("cus_XXXXX")
+
+        # But only one customer will exist - the original one
+        self.assertEqual(Customer.objects.count(), 1)
+        self.assertEqual(customer.stripe_id, "cus_YYYYY")
+
+        # Check that the customer hasn't been modified
+        self.assertEqual(customer.user, self.user)
+        self.assertEqual(customer.stripe_id, "cus_YYYYY")
         _, kwargs = CreateMock.call_args
         self.assertEqual(kwargs["email"], self.user.email)
         self.assertIsNone(kwargs["source"])
         self.assertIsNone(kwargs["plan"])
         self.assertIsNone(kwargs["trial_end"])
-
-        # But a customer *was* created, retrieved, and then disposed of.
-        RetrieveMock.assert_called_once_with("cus_YYYYY")
-        new_customer.delete.assert_called_once_with()
 
     @patch("pinax.stripe.actions.invoices.create_and_pay")
     @patch("pinax.stripe.actions.customers.sync_customer")


### PR DESCRIPTION
#### What's this PR do?
Steps to obtain a customer from a user

Before:
- create remote customer
- check if we have it locally on the db
- if yes, delete created remote customer
- if no, keep the created customer

After:
- check if we have it locally on the db
- if yes return it.
- if no, create remote customer and local customer

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [x] Has the appropriate documentation been updated (if applicable)?
- [x] Have you written tests to prove this change works (if applicable)?
