### PR TITLE
Remove support for unsupported versions of python and django

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,12 +43,6 @@ jobs:
       - image: circleci/python:2.7
         environment:
           TOXENV=py27-dj18
-  py27dj19:
-    <<: *common
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          TOXENV=py27-dj19
   py27dj110:
     <<: *common
     docker:
@@ -73,12 +67,6 @@ jobs:
       - image: circleci/python:3.4
         environment:
           TOXENV=py34-dj18
-  py34dj19:
-    <<: *common
-    docker:
-      - image: circleci/python:3.4
-        environment:
-          TOXENV=py34-dj19
   py34dj110:
     <<: *common
     docker:
@@ -103,12 +91,6 @@ jobs:
       - image: circleci/python:3.5
         environment:
           TOXENV=py35-dj18
-  py35dj19:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV=py35-dj19
   py35dj110:
     <<: *common
     docker:
@@ -148,9 +130,6 @@ workflows:
       - py27dj18:
           requires:
             - lint
-      - py27dj19:
-          requires:
-            - lint
       - py27dj110:
           requires:
             - lint
@@ -161,9 +140,6 @@ workflows:
           requires:
             - lint
       - py34dj18:
-          requires:
-            - lint
-      - py34dj19:
           requires:
             - lint
       - py34dj110:
@@ -177,9 +153,6 @@ workflows:
       #     requires:
       #       - lint
       - py35dj18:
-          requires:
-            - lint
-      - py35dj19:
           requires:
             - lint
       - py35dj110:

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,9 @@ show_missing = True
 [tox]
 envlist =
     checkqa
-    py27-dj{17,18,19,110,111}
-    py33-dj{17,18}
-    py34-dj{17,18,19,110,111,master}
-    py35-dj{18,19,110,111,master}
+    py27-dj{17,18,110,111}
+    py34-dj{17,18,110,111,master}
+    py35-dj{18,110,111,master}
     py36-dj{111,master}
 
 [testenv]
@@ -37,9 +36,7 @@ passenv = CI CIRCLECI CIRCLE_*
 deps =
     coverage
     codecov
-    dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11a1,<2.0
     master: https://github.com/django/django/tarball/master


### PR DESCRIPTION
#### What's this PR do?
Drop support for python3.3, django1.7 and django1.9 who all reached end of life.

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [x] Has the appropriate documentation been updated (if applicable)?
- [ ] Have you written tests to prove this change works (if applicable)?
