### PR TITLE
Remove Django 1.7 and master, add Django 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,9 +139,10 @@ workflows:
       - py34dj111:
           requires:
             - lint
-      - py34dj20:
-          requires:
-            - lint
+# Failing to start Django Tests for some reason
+#      - py34dj20:
+#          requires:
+#            - lint
       - py35dj18:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - image: circleci/python:3.4
         environment:
           TOXENV=py34-dj111
-  py34djmaster:
+  py34dj20:
     <<: *common
     docker:
       - image: circleci/python:3.4
@@ -97,7 +97,7 @@ jobs:
       - image: circleci/python:3.5
         environment:
           TOXENV=py35-dj111
-  py35djmaster:
+  py35dj20:
     <<: *common
     docker:
       - image: circleci/python:3.5
@@ -109,7 +109,7 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV=py36-dj111
-  py36djmaster:
+  py36dj20:
     <<: *common
     docker:
       - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,6 @@ jobs:
       - image: circleci/python:2.7
         environment:
           TOXENV=py27-dj111
-  py33dj18:
-    <<: *common
-    docker:
-      - image: circleci/python:3.3
-        environment:
-          TOXENV=py33-dj18
   py34dj18:
     <<: *common
     docker:
@@ -84,7 +78,7 @@ jobs:
     docker:
       - image: circleci/python:3.4
         environment:
-          TOXENV=py34-djmaster
+          TOXENV=py34-dj20
   py35dj18:
     <<: *common
     docker:
@@ -108,7 +102,7 @@ jobs:
     docker:
       - image: circleci/python:3.5
         environment:
-          TOXENV=py35-djmaster
+          TOXENV=py35-dj20
   py36dj111:
     <<: *common
     docker:
@@ -120,7 +114,7 @@ jobs:
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV=py36-djmaster
+          TOXENV=py36-dj20
 
 workflows:
   version: 2
@@ -136,9 +130,6 @@ workflows:
       - py27dj111:
           requires:
             - lint
-      - py33dj18:
-          requires:
-            - lint
       - py34dj18:
           requires:
             - lint
@@ -149,7 +140,7 @@ workflows:
           requires:
             - lint
       # Failing to start Django Tests for some reason
-      # - py34djmaster:
+      # - py34dj20:
       #     requires:
       #       - lint
       - py35dj18:
@@ -161,12 +152,12 @@ workflows:
       - py35dj111:
           requires:
             - lint
-      - py35djmaster:
+      - py35dj20:
           requires:
             - lint
       - py36dj111:
           requires:
             - lint
-      - py36djmaster:
+      - py36dj20:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,9 @@ workflows:
       - py34dj111:
           requires:
             - lint
-# Failing to start Django Tests for some reason
-#      - py34dj20:
-#          requires:
-#            - lint
+      - py34dj20:
+          requires:
+            - lint
       - py35dj18:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,9 @@ workflows:
       - py34dj111:
           requires:
             - lint
-      # Failing to start Django Tests for some reason
-      # - py34dj20:
-      #     requires:
-      #       - lint
+      - py34dj20:
+          requires:
+            - lint
       - py35dj18:
           requires:
             - lint

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ coverage.xml
 
 # MkDocs
 site/
+
+# IDEs
+.idea/

--- a/pinax/stripe/forms.py
+++ b/pinax/stripe/forms.py
@@ -5,7 +5,6 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 
 import stripe
-
 from ipware.ip import get_ip, get_real_ip
 
 from .actions import accounts

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11a1,<2.0
     dj20: Django<2.1
+    master: https://github.com/django/django/tarball/master
 usedevelop = True
 setenv =
    DJANGO_SETTINGS_MODULE=pinax.stripe.tests.settings

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,10 @@ show_missing = True
 [tox]
 envlist =
     checkqa
-    py27-dj{17,18,110,111}
-    py34-dj{17,18,110,111,master}
-    py35-dj{18,110,111,master}
-    py36-dj{111,master}
+    py27-dj{18,110,111}
+    py34-dj{18,110,111,20}
+    py35-dj{18,110,111,20}
+    py36-dj{111,20}
     pytest{,-coverage}
 
 [testenv]
@@ -40,7 +40,7 @@ deps =
     dj18: Django>=1.8,<1.9
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11a1,<2.0
-    master: https://github.com/django/django/tarball/master
+    dj20: Django<2.1
 usedevelop = True
 setenv =
    DJANGO_SETTINGS_MODULE=pinax.stripe.tests.settings


### PR DESCRIPTION
#### What's this PR do?

Small test matrix dependency cleanup:
* Remove all references to Django 1.7.
* Remove reference to "master".
* Add Django 2.0 explicitly to test matrix.

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR? NO
- [x] Have all new dependencies been documented in this PR? YES
- [x] Has the appropriate documentation been updated (if applicable)? N/A
- [x] Have you written tests to prove this change works (if applicable)? N/A
