### PR TITLE
sync_customer: move sync of sources/subs to management command

### DIFF
--- a/pinax/stripe/actions/customers.py
+++ b/pinax/stripe/actions/customers.py
@@ -3,7 +3,7 @@ from django.utils.encoding import smart_str
 
 import stripe
 
-from . import invoices, sources, subscriptions
+from . import invoices
 from .. import hooks, models, utils
 from ..conf import settings
 
@@ -162,7 +162,3 @@ def sync_customer(customer, cu=None):
     customer.delinquent = cu["delinquent"]
     customer.default_source = cu["default_source"] or ""
     customer.save()
-    for source in cu["sources"]["data"]:
-        sources.sync_payment_source_from_stripe_data(customer, source)
-    for subscription in cu["subscriptions"]["data"]:
-        subscriptions.sync_subscription_from_stripe_data(customer, subscription)

--- a/pinax/stripe/management/commands/sync_customers.py
+++ b/pinax/stripe/management/commands/sync_customers.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 
 from stripe.error import InvalidRequestError
 
-from ...actions import charges, customers, invoices
+from ...actions import charges, customers, invoices, sources, subscriptions
 
 
 class Command(BaseCommand):
@@ -33,3 +33,9 @@ class Command(BaseCommand):
             if customer.date_purged is None:
                 invoices.sync_invoices_for_customer(customer)
                 charges.sync_charges_for_customer(customer)
+
+                cu = customer.stripe_customer
+                for source in cu["sources"]["data"]:
+                    sources.sync_payment_source_from_stripe_data(customer, source)
+                for subscription in cu["subscriptions"]["data"]:
+                    subscriptions.sync_subscription_from_stripe_data(customer, subscription)

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -1245,8 +1245,8 @@ class SyncsTests(TestCase):
         self.assertEquals(customer.currency, "usd")
         self.assertEquals(customer.delinquent, False)
         self.assertEquals(customer.default_source, "")
-        self.assertTrue(SyncPaymentSourceMock.called)
-        self.assertTrue(SyncSubscriptionMock.called)
+        self.assertFalse(SyncPaymentSourceMock.called)
+        self.assertFalse(SyncSubscriptionMock.called)
 
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
     @patch("pinax.stripe.actions.sources.sync_payment_source_from_stripe_data")
@@ -1265,8 +1265,8 @@ class SyncsTests(TestCase):
         self.assertEquals(customer.currency, "usd")
         self.assertEquals(customer.delinquent, False)
         self.assertEquals(customer.default_source, "")
-        self.assertTrue(SyncPaymentSourceMock.called)
-        self.assertTrue(SyncSubscriptionMock.called)
+        self.assertFalse(SyncPaymentSourceMock.called)
+        self.assertFalse(SyncSubscriptionMock.called)
 
     @patch("pinax.stripe.actions.customers.purge_local")
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")


### PR DESCRIPTION
This does not really fix `sources.sync_payment_source_from_stripe_data`, but
moves it out of the webhook processing, where it might cause the whole
event to be discarded.

After all there should be separate events for changes sources and
subscriptions.

Ref: https://github.com/pinax/pinax-stripe/issues/383.