### PR TITLE
Fix sync_payment_source_from_stripe_data to not crash with sources

### DIFF
--- a/pinax/stripe/actions/sources.py
+++ b/pinax/stripe/actions/sources.py
@@ -42,7 +42,7 @@ def sync_card(customer, source):
 
     Args:
         customer: the customer to create or update a card for
-        source: data reprenting the card from the Stripe API
+        source: data representing the card from the Stripe API
     """
     defaults = dict(
         customer=customer,
@@ -113,9 +113,10 @@ def sync_payment_source_from_stripe_data(customer, source):
         customer: the customer to create or update a Bitcoin receiver for
         source: data reprenting the payment source from the Stripe API
     """
-    if source["id"].startswith("card_"):
+    if source["object"] == "card":
         return sync_card(customer, source)
-    else:
+    # NOTE: this does not seem to be a thing anymore?!
+    if source["object"] == "bitcoin_receiver":
         return sync_bitcoin(customer, source)
 
 

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -1089,6 +1089,43 @@ class SyncsTests(TestCase):
         sources.sync_payment_source_from_stripe_data(self.customer, source)
         self.assertEquals(Card.objects.get(stripe_id=source["id"]).exp_year, 2022)
 
+    def test_sync_payment_source_from_stripe_data_source_card(self):
+        source = {
+            "id": "src_123",
+            "object": "source",
+            "amount": None,
+            "client_secret": "src_client_secret_123",
+            "created": 1483575790,
+            "currency": None,
+            "flow": "none",
+            "livemode": False,
+            "metadata": {},
+            "owner": {
+                "address": None,
+                "email": None,
+                "name": None,
+                "phone": None,
+                "verified_address": None,
+                "verified_email": None,
+                "verified_name": None,
+                "verified_phone": None,
+            },
+            "status": "chargeable",
+            "type": "card",
+            "usage": "reusable",
+            "card": {
+                "brand": "Visa",
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2034,
+                "funding": "debit",
+                "last4": "5556",
+                "three_d_secure": "not_supported"
+            }
+        }
+        sources.sync_payment_source_from_stripe_data(self.customer, source)
+        self.assertFalse(Card.objects.exists())
+
     def test_sync_payment_source_from_stripe_data_bitcoin(self):
         source = {
             "id": "btcrcv_17BE32I10iPhvocMqViUU1w4",


### PR DESCRIPTION
This handles "source" objects now without crashing, but does not create
Card objects from the data therein.

I think that should get done probably?!

Helps with https://github.com/pinax/pinax-stripe/issues/383.