### PR TITLE
Fix CustomerUpdatedWebhook: do not call sync_customer without customer

### DIFF
--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -291,11 +291,7 @@ class CustomerUpdatedWebhook(Webhook):
 
     def process_webhook(self):
         if self.event.customer:
-            cu = None
-            try:
-                cu = self.event.message["data"]["object"]
-            except (KeyError, TypeError):
-                pass
+            cu = self.event.message["data"]["object"]
             customers.sync_customer(self.event.customer, cu)
 
 

--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -290,12 +290,13 @@ class CustomerUpdatedWebhook(Webhook):
     description = "Occurs whenever any property of a customer changes."
 
     def process_webhook(self):
-        cu = None
-        try:
-            cu = self.event.message["data"]["object"]
-        except (KeyError, TypeError):
-            pass
-        customers.sync_customer(self.event.customer, cu)
+        if self.event.customer:
+            cu = None
+            try:
+                cu = self.event.message["data"]["object"]
+            except (KeyError, TypeError):
+                pass
+            customers.sync_customer(self.event.customer, cu)
 
 
 class CustomerDiscountCreatedWebhook(Webhook):


### PR DESCRIPTION
Otherwise the `if customer.date_purged` in `customers.sync_customer`
fails.

The alternative might be to actually try fetching the customer, but I do
not think a local customer should be created, if it failed before, or
was deleted etc?!