### PR TITLE
tox: better pytest integration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,10 @@ show_missing = True
 [tox]
 envlist =
     checkqa
-    py27-dj{18,110,111}
-    py34-dj{18,110,111,20}
-    py35-dj{18,110,111,20}
-    py36-dj{111,20}
-    pytest{,-coverage}
+    py27-dj{18,110,111}{,-pytest}
+    py34-dj{18,110,111,20}{,-pytest}
+    py35-dj{18,110,111,20}{,-pytest}
+    py36-dj{111,20}{,-pytest}
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*
@@ -43,25 +42,15 @@ deps =
     dj111: Django>=1.11a1,<2.0
     dj20: Django<2.1
     master: https://github.com/django/django/tarball/master
+extras =
+    pytest: pytest
 usedevelop = True
 setenv =
    DJANGO_SETTINGS_MODULE=pinax.stripe.tests.settings
+   pytest: _STRIPE_TEST_RUNNER=-m pytest
 commands =
-    coverage run setup.py test {posargs}
+    coverage run {env:_STRIPE_TEST_RUNNER:setup.py test} {posargs}
     coverage report -m --skip-covered
-
-[testenv:pytest]
-extras = pytest
-deps =
-commands =
-    pytest {posargs}
-
-[testenv:pytest-coverage]
-extras = pytest
-deps =
-    pytest-cov
-commands =
-    pytest --cov --cov-report=term-missing:skip-covered {posargs}
 
 [testenv:checkqa]
 commands =


### PR DESCRIPTION
This adds a "pytest" factor, so that e.g. "tox -e py27-pytest" can be
used.