### PR TITLE
CircleCI: do not require lint success for tests to run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,49 +124,21 @@ jobs:
 
 workflows:
   version: 2
-  lint-and-test:
+  test:
     jobs:
       - lint
-      - py27dj18:
-          requires:
-            - lint
-      - py27dj110:
-          requires:
-            - lint
-      - py27dj111:
-          requires:
-            - lint
-      - py33dj18:
-          requires:
-            - lint
-      - py34dj18:
-          requires:
-            - lint
-      - py34dj110:
-          requires:
-            - lint
-      - py34dj111:
-          requires:
-            - lint
+      - py27dj18
+      - py27dj110
+      - py27dj111
+      - py33dj18
+      - py34dj18
+      - py34dj110
+      - py34dj111
       # Failing to start Django Tests for some reason
       # - py34djmaster:
-      #     requires:
-      #       - lint
-      - py35dj18:
-          requires:
-            - lint
-      - py35dj110:
-          requires:
-            - lint
-      - py35dj111:
-          requires:
-            - lint
-      - py35djmaster:
-          requires:
-            - lint
-      - py36dj111:
-          requires:
-            - lint
-      - py36djmaster:
-          requires:
-            - lint
+      - py35dj18
+      - py35dj110
+      - py35dj111
+      - py35djmaster
+      - py36dj111
+      - py36djmaster


### PR DESCRIPTION
In case of e.g. bad quotes it is still useful to know if tests are
passing (and coverage is OK), or if you need to fix them, too.

It will also make tests finish faster since CircleCI will start ~4 jobs right away, instead of waiting for "lint" to finish.