### PR TITLE
tox: isort: skip migrations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ multi_line_output=3
 known_django=django
 known_third_party=stripe,six,mock,appconf,jsonfield
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+skip_glob=*/pinax/stripe/migrations/*
 
 [coverage:run]
 source = pinax


### PR DESCRIPTION
Included in other PRs, but crucial to not fail with auto-generated migrations.