### PR TITLE
setup.cfg: add opts for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ universal = 1
 [tool:pytest]
 testpaths = pinax/stripe/tests
 DJANGO_SETTINGS_MODULE = pinax.stripe.tests.settings
+addopts = --reuse-db -ra --nomigrations


### PR DESCRIPTION
This makes it faster, especially when used with PostgreSQL.