### PR TITLE
tests: fix/improve test_sync_invoice_items_updating

### DIFF
--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -2126,11 +2126,12 @@ class SyncsTests(TestCase):
             "type": "subscription"
         }]
         invoices.sync_invoice_items(invoice, items)
-        self.assertTrue(invoice.items.all().count(), 2)
+        self.assertEquals(invoice.items.count(), 2)
+
         items[1].update({"description": "This is your second subscription"})
         invoices.sync_invoice_items(invoice, items)
-        self.assertTrue(invoice.items.all().count(), 2)
-        self.assertEquals(invoice.items.all()[1].description, "This is your second subscription")
+        self.assertEquals(invoice.items.count(), 2)
+        self.assertEquals(invoice.items.get(stripe_id="sub_7Q4BX0HMfqTpN9").description, "This is your second subscription")
 
     @patch("pinax.stripe.hooks.hookset.send_receipt")
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")


### PR DESCRIPTION
It improves the test in general, and is required when testing with PostgreSQL (https://github.com/pinax/pinax-stripe/pull/430).