### PR TITLE
Remove leftovers for django_forms_bootstrap

### DIFF
--- a/makemigrations.py
+++ b/makemigrations.py
@@ -28,7 +28,6 @@ DEFAULT_SETTINGS = dict(
         "django.contrib.contenttypes",
         "django.contrib.sessions",
         "django.contrib.sites",
-        "django_forms_bootstrap",
         "jsonfield",
         "pinax.stripe",
     ],

--- a/pinax/stripe/tests/settings.py
+++ b/pinax/stripe/tests/settings.py
@@ -23,7 +23,6 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.sites",
-    "django_forms_bootstrap",
     "jsonfield",
     "pinax.stripe",
 ]

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ recurring subscriptions managed by Stripe.
 
 tests_require = [
     "mock",
-    "django_forms_bootstrap",
 ]
 
 setup(


### PR DESCRIPTION
It seems to have been removed in b92a399, but was still installed and
imported with tests.