### PR TITLE
Webhook.post: save api_version with events

### DIFF
--- a/pinax/stripe/tests/test_webhooks.py
+++ b/pinax/stripe/tests/test_webhooks.py
@@ -46,6 +46,7 @@ class WebhookRegistryTest(TestCase):
 class WebhookTests(TestCase):
 
     event_data = {
+        "api_version": "2017-06-05",
         "created": 1348360173,
         "data": {
             "object": {

--- a/pinax/stripe/views.py
+++ b/pinax/stripe/views.py
@@ -209,6 +209,7 @@ class Webhook(View):
                 stripe_id=data["id"],
                 kind=data["type"],
                 livemode=data["livemode"],
+                api_version=data["api_version"],
                 message=data
             )
         return HttpResponse()


### PR DESCRIPTION
I think it could be a property instead maybe, but that is the smaller fix for now (without needing a migration).