### PR TITLE
coverage: use default exclude_lines and clean up

### DIFF
--- a/pinax/stripe/middleware.py
+++ b/pinax/stripe/middleware.py
@@ -6,21 +6,21 @@ from .conf import settings
 
 try:
     from django.urls import resolve
-except ImportError:  # coverage: omit
-    from django.core.urlresolvers import resolve  # coverage: omit
+except ImportError:
+    from django.core.urlresolvers import resolve
 
 try:
     from django.utils.deprecation import MiddlewareMixin as MixinorObject
-except ImportError:  # coverage: omit
-    MixinorObject = object  # coverage: omit
+except ImportError:
+    MixinorObject = object
 
 
 class ActiveSubscriptionMiddleware(MixinorObject):
 
     def process_request(self, request):
         is_authenticated = request.user.is_authenticated
-        if django.VERSION < (1, 10):  # coverage: omit
-            is_authenticated = is_authenticated()  # coverage: omit
+        if django.VERSION < (1, 10):
+            is_authenticated = is_authenticated()
 
         if is_authenticated and not request.user.is_staff:
             url_name = resolve(request.path).url_name

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,6 @@ data_file = .coverage
 
 [coverage:report]
 omit = pinax/stripe/conf.py,pinax/stripe/tests/*,pinax/stripe/migrations/*
-exclude_lines =
-    coverage: omit
 show_missing = True
 
 [tox]


### PR DESCRIPTION
"pragma: no cover" is used in newer code already, and not being
ignored/handled correctly.  (https://codecov.io/gh/lock8/pinax-stripe/src/next/pinax/stripe/forms.py#L258)

This also removes "coverage: omit" for where we have actual coverage,
when merging reports.