### PR TITLE
Revert "CircleCI: test merge commit"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,23 +4,6 @@ common: &common
   working_directory: ~/repo
   steps:
     - checkout
-    - run:
-        name: checkout merge commit for PRs
-        command: |
-          set -x
-          PR_NUMBER=${CI_PULL_REQUEST//*pull\//}
-          if [ -n "$PR_NUMBER" ]; then
-            merge_ref="refs/pull/$PR_NUMBER/merge"
-            if ! git ls-remote -q --exit-code origin "$merge_ref"; then
-              echo -e "\033[0;31mWarning: remote merge ref for $PR_NUMBER not found on origin: $merge_ref."
-              echo -e "Not checking out merge commit.\033[0m"
-            elif ! git pull --ff-only origin "refs/pull/$PR_NUMBER/merge"; then
-            echo
-              echo -e "\033[0;31mERROR: Failed to merge your branch with the latest master."
-              echo -e "Please manually merge master into your branch, and push the changes to GitHub.\033[0m"
-              exit 1
-            fi
-          fi
     - restore_cache:
         keys:
           - v2-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}


### PR DESCRIPTION
This reverts commit 3103cffaa605721d58f9be53bd43778af608343f.

As outlined in [1] it causes issues with Codecov, when we report
coverage for the merge commit, but it is then applied to the commit
itself.

1: https://github.com/pinax/pinax-stripe/pull/422#issuecomment-340476498