### PR TITLE
actions.subscriptions.cancel: skip GET

### DIFF
--- a/pinax/stripe/actions/subscriptions.py
+++ b/pinax/stripe/actions/subscriptions.py
@@ -16,7 +16,12 @@ def cancel(subscription, at_period_end=True):
         subscription: the subscription to cancel
         at_period_end: True to cancel at the end of the period, otherwise cancels immediately
     """
-    sub = subscription.stripe_subscription.delete(at_period_end=at_period_end)
+    sub = stripe.Subscription(
+        subscription.stripe_id,
+        stripe_account=subscription.stripe_account_stripe_id,
+    ).delete(
+        at_period_end=at_period_end,
+    )
     return sync_subscription_from_stripe_data(subscription.customer, sub)
 
 


### PR DESCRIPTION
Skip retrieving the Stripe subscription object when deleting it.

Fixes https://github.com/pinax/pinax-stripe/issues/491.