### PR TITLE
Customize Customer str() repr() to include account ready users

### DIFF
--- a/pinax/stripe/models.py
+++ b/pinax/stripe/models.py
@@ -252,14 +252,26 @@ class Customer(AccountRelatedStripeObject):
         )
 
     def __str__(self):
-        return str(self.user)
+        if self.user:
+            return str(self.user)
+        elif self.id:
+            return ", ".join(str(user) for user in self.users.all())
+        return "No User(s)"
 
     def __repr__(self):
-        return "Customer(pk={!r}, user={!r}, stripe_id={!r})".format(
-            self.pk,
-            self.user,
-            str(self.stripe_id),
-        )
+        if self.user:
+            return "Customer(pk={!r}, user={!r}, stripe_id={!r})".format(
+                self.pk,
+                self.user,
+                str(self.stripe_id),
+            )
+        elif self.id:
+            return "Customer(pk={!r}, users={}, stripe_id={!r})".format(
+                self.pk,
+                ", ".join(repr(user) for user in self.users.all()),
+                str(self.stripe_id),
+            )
+        return "Customer(pk={!r}, stripe_id={!r})".format(self.pk, str(self.stripe_id))
 
 
 class Card(StripeObject):

--- a/pinax/stripe/tests/test_models.py
+++ b/pinax/stripe/tests/test_models.py
@@ -63,8 +63,23 @@ class ModelTests(TestCase):
 
     def test_customer_str_and_repr(self):
         c = Customer()
-        self.assertTrue("None" in str(c))
-        self.assertEquals(repr(c), "Customer(pk=None, user=None, stripe_id='')")
+        self.assertTrue("No User(s)" in str(c))
+        self.assertEquals(repr(c), "Customer(pk=None, stripe_id='')")
+
+    def test_customer_with_user_str_and_repr(self):
+        User = get_user_model()
+        c = Customer(user=User())
+        self.assertEqual(str(c), "")
+        self.assertEqual(repr(c), "Customer(pk=None, user=<User: >, stripe_id='')")
+
+    def test_connected_customer_str_and_repr(self):
+        User = get_user_model()
+        user = User.objects.create()
+        account = Account.objects.create(stripe_id="acc_A")
+        customer = Customer.objects.create(stripe_id="cus_A", stripe_account=account)
+        UserAccount.objects.create(customer=customer, user=user, account=account)
+        self.assertEqual(str(customer), "")
+        self.assertEqual(repr(customer), "Customer(pk={c.pk}, users=<User: >, stripe_id='cus_A')".format(c=customer))
 
     def test_charge_repr(self):
         charge = Charge()
@@ -169,7 +184,7 @@ class ModelTests(TestCase):
         self.assertEquals(
             repr(ua),
             "UserAccount(pk=None, user=<User: >, account=Account(pk=None, display_name='', type=None, stripe_id='', authorized=True)"
-            ", customer=Customer(pk=None, user=None, stripe_id=''))")
+            ", customer=Customer(pk=None, stripe_id=''))")
 
 
 class StripeObjectTests(TestCase):


### PR DESCRIPTION
#### What's this PR do?
Customize str(Customer) and repr(Customer) to reflect users coming from UserAccounts

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [ ] Has the appropriate documentation been updated (if applicable)?
- [x] Have you written tests to prove this change works (if applicable)?
