### PR TITLE
tox: fix check_migrated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,8 @@ deps =
     isort == 4.2.15
 
 [testenv:check_migrated]
-env =
+setenv =
     DJANGO_SETTINGS_MODULE=pinax.stripe.tests.settings
+passenv =
 commands =
     django-admin makemigrations --check -v3 --dry-run --noinput pinax_stripe


### PR DESCRIPTION
- use setenv instead of (ignored) env
- do not pass any envs (especially PINAX_STRIPE_DATABASE_ENGINE, which
  would require to install psycopg2 maybe in the tox env)