### PR TITLE
Update stripe api version (to fix some issues)

### DIFF
--- a/pinax/stripe/conf.py
+++ b/pinax/stripe/conf.py
@@ -29,7 +29,7 @@ class PinaxStripeAppConf(AppConf):
 
     PUBLIC_KEY = None
     SECRET_KEY = None
-    API_VERSION = "2015-10-16"
+    API_VERSION = "2017-01-27"
     INVOICE_FROM_EMAIL = "billing@example.com"
     DEFAULT_PLAN = None
     HOOKSET = "pinax.stripe.hooks.DefaultHookSet"


### PR DESCRIPTION
I'm initiating this api version bump because I'm encountering an issue
where when getting a failed invoice, pinax stripe is trying to get the
subscription, and if the subscription is already cancelled, it wouldn't
show. This has been changed (fixed?) in stripe API 2016-07-06.

I've taken the opportunity to upgrade to a slightly newer api version
since I've reviewed the changes and non of them look like they would
negatively affect pinax.stripe.

Way to reproduce my invoice issue:

Have a cancelled subscription followed by a cancelled invoice (happens
often here). Following that you'd get the following backtrace:

File "pinax/stripe/webhooks.py" in process
  118.             self.process_webhook()

File "pinax/stripe/webhooks.py" in process_webhook
  414.             send_receipt=settings.PINAX_STRIPE_SEND_EMAIL_RECEIPTS

File "pinax/stripe/actions/invoices.py" in sync_invoice_from_stripe_data
  91.     stripe_subscription = subscriptions.retrieve(c, sub_id)

File "pinax/stripe/actions/subscriptions.py" in retrieve
  128.     subscription = stripe.Subscription.retrieve(sub_id, stripe_account=customer.stripe_account_stripe_id)

File "stripe/api_resources/abstract/api_resource.py" in retrieve
  13.         instance.refresh()

File "stripe/api_resources/abstract/api_resource.py" in refresh
  17.         self.refresh_from(self.request('get', self.instance_url()))

File "stripe/stripe_object.py" in request
  190.         response, api_key = requestor.request(method, url, params, headers)

File "stripe/api_requestor.py" in request
  152.         resp = self.interpret_response(rbody, rcode, rheaders)

File "stripe/api_requestor.py" in interpret_response
  359.             self.handle_error_response(rbody, rcode, resp, rheaders)

File "stripe/api_requestor.py" in handle_error_response
  177.         raise err

Exception Type: InvalidRequestError at /stripe/webhook/
Exception Value: Request req_XXXXXXXX  No such subscription:
sub_XXXXXXXXXX

req and sub were redacted by me.

#### What's this PR do?

#### Any background context you want to provide?

#### What ticket or issue # does this fix?

Opened this instead of opening a ticket for the above issue.

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
There should be none, as I only upgraded to an API version that didn't change anything that would affect pinax stripe.
- [x] Have all new dependencies been documented in this PR?
None.
- [x] Has the appropriate documentation been updated (if applicable)?
No relevant ones as I can see.
- [x] Have you written tests to prove this change works (if applicable)?
The normal test suite should cover it.