### PR TITLE
account.application.deauthorized: remove ValueError

### DIFF
--- a/pinax/stripe/tests/test_webhooks.py
+++ b/pinax/stripe/tests/test_webhooks.py
@@ -606,19 +606,6 @@ class AccountWebhookTest(TestCase):
             AccountApplicationDeauthorizeWebhook(event).process()
 
     @patch("stripe.Event.retrieve")
-    def test_process_deauthorize_with_authorizes_account(self, RetrieveMock):
-        stripe_account_id = self.account.stripe_id
-        data = {"data": {"object": {"id": "evt_002"}},
-                "account": stripe_account_id}
-        event = Event.objects.create(
-            kind=AccountApplicationDeauthorizeWebhook.name,
-            webhook_message=data,
-        )
-        RetrieveMock.return_value.to_dict.return_value = data
-        with self.assertRaises(ValueError):
-            AccountApplicationDeauthorizeWebhook(event).process()
-
-    @patch("stripe.Event.retrieve")
     def test_process_deauthorize_with_delete_account(self, RetrieveMock):
         data = {"data": {"object": {"id": "evt_002"}},
                 "account": "acct_bb"}

--- a/pinax/stripe/webhooks.py
+++ b/pinax/stripe/webhooks.py
@@ -164,12 +164,11 @@ class AccountApplicationDeauthorizeWebhook(Webhook):
 
         When this event is for a connected account we should not be able to
         fetch the event anymore (since we have been disconnected).
+        But there might be multiple connections (e.g. for Dev/Prod).
 
-        Therefore we try to retrieve the event:
-         - in case of PermissionError exception, everything is perfectly normal.
-           It means the account has been deauthorized.
-         - In case no exception has been caught, then, most likely, the event has been forged
-           to make you believe the account has been disabled despite it is still functioning.
+        Therefore we try to retrieve the event, and handle a
+        PermissionError exception to be expected (since we cannot access the
+        account anymore).
         """
         try:
             super(AccountApplicationDeauthorizeWebhook, self).validate()
@@ -178,11 +177,8 @@ class AccountApplicationDeauthorizeWebhook(Webhook):
                 stripe_account_id = self.stripe_account.stripe_id
                 if not(stripe_account_id in str(exc) and obfuscate_secret_key(settings.PINAX_STRIPE_SECRET_KEY) in str(exc)):
                     raise exc
-        else:
-            if self.stripe_account:
-                raise ValueError("The remote account is still valid. This might be a hostile event")
-        self.event.valid = True
-        self.event.validated_message = self.event.webhook_message
+            self.event.valid = True
+            self.event.validated_message = self.event.webhook_message
 
     def process_webhook(self):
         if self.stripe_account is not None:


### PR DESCRIPTION
The account might still be accessible, e.g. if it was connected multiple
times.