### PR TITLE
Fix get_form_kwargs example in connect docs

### DIFF
--- a/docs/user-guide/connect.md
+++ b/docs/user-guide/connect.md
@@ -86,12 +86,10 @@ class CreateCustomAccountView(FormView):
     form_class = InitialCustomAccountForm
     template_name = '<path to your template>'
 
-    def get_form_kwargs(self, *args, **kwargs):
+    def get_form_kwargs(self):
         form_kwargs = super(
-            CreateBankAccountView, self
-        ).get_form_kwargs(
-            *args, **kwargs
-        )
+            CreateCustomAccountView, self
+        ).get_form_kwargs()
         initial = form_kwargs.pop('initial', {})
         form_kwargs['request'] = self.request
         form_kwargs['country'] = 'US'


### PR DESCRIPTION
Fixed the class name in `super()`.

The [`get_form_kwargs`][1] method does not accept *args or **kwargs, so I removed them to simplify the code.

#### What ticket or issue # does this fix?

Closes #512

[1]: https://docs.djangoproject.com/en/2.0/ref/class-based-views/mixins-editing/#django.views.generic.edit.FormMixin.get_form_kwargs
