### PR TITLE
Update django-ipware requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "django>=1.8",
         "pytz",
         "six",
-        "django-ipware==1.1.6"
+        "django-ipware==2.1.0"
     ],
     extras_require={
         "pytest": ["pytest", "pytest-django"] + tests_require,


### PR DESCRIPTION
Require django-ipware==2.1.0. Works with current version of django-pinax and solves dependency issues with other packages that require newer versions of django-ipware.

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
