### PR TITLE
Don't try to charge a customer with no card

### DIFF
--- a/pinax/stripe/management/commands/init_customers.py
+++ b/pinax/stripe/management/commands/init_customers.py
@@ -11,5 +11,5 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         User = get_user_model()
         for user in User.objects.filter(customer__isnull=True):
-            customers.create(user=user)
+            customers.create(user=user, charge_immediately=False)
             self.stdout.write("Created customer for {0}\n".format(user.email))


### PR DESCRIPTION
Stripe throws an error because we try to make a charge without having a card. Because we don't have a card for this user yet, it doesn't make sense to charge them immediately.

#### What's this PR do?

Fixes an exception thrown by Stripe because we try to do something that doesn't make sense: charge a customer who doesn't have a card on file.

#### Any background context you want to provide?

#### What ticket or issue # does this fix?

Closes #563

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [ ] Has the appropriate documentation been updated (if applicable)?
- [ ] Have you written tests to prove this change works (if applicable)?
