### PR TITLE
CircleCI: do not use unversioned cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ common: &common
     - restore_cache:
         keys:
           - v2-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-          - v2-deps-
     - run:
         name: install dependencies
         command: pip install --user tox

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "django>=1.8",
         "pytz",
         "six",
-        "django-ipware==1.1.6"
+        "django-ipware==2.1.0"
     ],
     extras_require={
         "pytest": ["pytest", "pytest-django"] + tests_require,


### PR DESCRIPTION
Fixes build failure when upgrading e.g. django-ipware
(https://circleci.com/gh/pinax/pinax-stripe/7999).