### PR TITLE
Remove bank account action

### DIFF
--- a/pinax/stripe/actions/externalaccounts.py
+++ b/pinax/stripe/actions/externalaccounts.py
@@ -1,5 +1,6 @@
-from .. import models
 import stripe
+
+from .. import models
 
 
 def create_bank_account(account, account_number, country, currency, **kwargs):
@@ -65,10 +66,9 @@ def sync_bank_account_from_stripe_data(data):
     return obj
 
 
-
 def delete_bank_account(account, bank_account):
     """
-    Create or update using the account object from a Stripe API query.
+    Deletes an external bank account from Stripe and Updates DB
 
     Important: The user must have another bank account with default_for_currency set to True
 
@@ -96,9 +96,3 @@ def delete_bank_account(account, bank_account):
         print(E)
 
     return False
-
-
-
-
-
-


### PR DESCRIPTION
#### What's this PR do?

This PR adds the ability to remove an external bank account from account. 

#### Any background context you want to provide?

Right now, we are able to sync accounts (update/add) from current stripe data, but it would be great to have actions to do with deletions.

For example: User creates a custom account, which automatically creates an external bank account.

If this user changes their payment method and decides to add new account (using stripe API), we can use  `sync_account()` to update our account/external_bank_accounts.

However, the user now wants to delete their previous (very first external bank account). We do this using stripe API:

```
account = stripe.Account.retrieve("acct_19c2PSCoyI6kORCB")
account.external_accounts.retrieve("ba_1CfV4JCoyI6kORCBWALOqwBd").delete()
```

This time, we need to manually remove this from `BankAccount` object, because syncing the data will not remove, but instead only add/update existing accounts.

#### What ticket or issue # does this fix?

Closes #569 

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [] Has the appropriate documentation been updated (if applicable)?
- [] Have you written tests to prove this change works (if applicable)?
