### PR TITLE
Pin Stripe Library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ common: &common
     - checkout
     - restore_cache:
         keys:
-          - v2-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - v3-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -28,7 +28,7 @@ common: &common
           - ~/.cache/pip
           - ~/.local
           - ./eggs
-        key: v2-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+        key: v3-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+Pipfile
+Pipfile.lock
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 4.3.1 - 2018-08-04
+
+* Pin `python-stripe` to `>2.0` as that major release broke things in `pinax-stripe` [PR 580](https://github.com/pinax/pinax-stripe/pull/580)
+
+
 ## 3.4.1 - 2017-04-21
 
 This fixes a bug that was introduced in `3.4.0` with customer creation taking a `quantity` parameter.

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     install_requires=[
         "django-appconf>=1.0.1",
         "jsonfield>=1.0.3",
-        "stripe>=1.7.9",
+        "stripe>=1.7.9, <2.0",
         "django>=1.8",
         "pytz",
         "six",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     author_email=AUTHOR_EMAIL,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    version="4.3.0",
+    version="4.3.1",
     license="MIT",
     url=URL,
     packages=find_packages(),


### PR DESCRIPTION
#### What's this PR do?

This will pin stripe library to <2.0 so we can offer a version of `pinax-stripe` for those who do not wish to upgrade to the latest stripe library (which pinax-stripe is currently not compatible with but will be soon).

#### What ticket or issue # does this fix?

Related to #574 #579 #578
