### PR TITLE
Pin to greater than 2.0 for python-stripe

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,7 +2,7 @@
 
 ## 4.4.0 - 2018-08-04
 
-* Pin `python-stripe` to `>2.0` after the merge of [PR 574](https://github.com/pinax/pinax-stripe/pull/574) which fixed compatibility.
+* Pin `python-stripe` to `>2.0` after the merge of [PR 574](https://github.com/pinax/pinax-stripe/pull/574) which fixed compatibility. [PR 581](https://github.com/pinax/pinax-stripe/pull/581)
 
 
 ## 4.3.1 - 2018-08-04

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,8 +1,13 @@
 # Release Notes
 
+## 4.4.0 - 2018-08-04
+
+* Pin `python-stripe` to `>2.0` after the merge of [PR 574](https://github.com/pinax/pinax-stripe/pull/574) which fixed compatibility.
+
+
 ## 4.3.1 - 2018-08-04
 
-* Pin `python-stripe` to `>2.0` as that major release broke things in `pinax-stripe` [PR 580](https://github.com/pinax/pinax-stripe/pull/580)
+* Pin `python-stripe` to `<2.0` as that major release broke things in `pinax-stripe` [PR 580](https://github.com/pinax/pinax-stripe/pull/580)
 
 
 ## 3.4.1 - 2017-04-21

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     author_email=AUTHOR_EMAIL,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    version="4.3.1",
+    version="4.4.0",
     license="MIT",
     url=URL,
     packages=find_packages(),
@@ -88,7 +88,7 @@ setup(
     install_requires=[
         "django-appconf>=1.0.1",
         "jsonfield>=1.0.3",
-        "stripe>=1.7.9, <2.0",
+        "stripe>=2.0",
         "django>=1.8",
         "pytz",
         "six",


### PR DESCRIPTION
#### What's this PR do?

Updates package to require `python-stripe>=2.0`

#### What ticket or issue # does this fix?

Closes #578 #579 
Related to #574 and #580
