### PR TITLE
Document sync_coupons management command.

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -20,3 +20,7 @@ Utilizes the following actions:
 Make sure your Stripe account has the plans.
 
 Utilizes `pinax.stripe.actions.plans.sync_plans`.
+
+#### pinax.stripe.management.commands.sync_coupons
+
+Creates `pinax.stripe.models.Coupon` objects for existing coupons in Stripe account.


### PR DESCRIPTION
#### What's this PR do?
sync_coupons is a management command already provided by pinax-stripe. This adds it to the docs.
