### PR TITLE
Do not call deprecated methods on stripe.Customer

### DIFF
--- a/pinax/stripe/actions/charges.py
+++ b/pinax/stripe/actions/charges.py
@@ -160,7 +160,7 @@ def sync_charges_for_customer(customer):
     Args:
         customer: a pinax.stripe.models.Customer object
     """
-    for charge in customer.stripe_customer.charges().data:
+    for charge in stripe.Charge.auto_paging_iter(customer=customer.stripe_id):
         sync_charge_from_stripe_data(charge)
 
 

--- a/pinax/stripe/actions/invoices.py
+++ b/pinax/stripe/actions/invoices.py
@@ -131,9 +131,7 @@ def sync_invoices_for_customer(customer):
     Args:
         customer: the customer for whom to synchronize all invoices
     """
-    stripe_customer = customer.stripe_customer
-    stripe_invoices = stripe.Invoice.list(customer=stripe_customer.id)
-    for invoice in stripe_invoices.data:
+    for invoice in stripe.Invoice.auto_paging_iter(customer=customer.stripe_id):
         sync_invoice_from_stripe_data(invoice, send_receipt=False)
 
 

--- a/pinax/stripe/actions/invoices.py
+++ b/pinax/stripe/actions/invoices.py
@@ -131,7 +131,9 @@ def sync_invoices_for_customer(customer):
     Args:
         customer: the customer for whom to synchronize all invoices
     """
-    for invoice in customer.stripe_customer.invoices().data:
+    stripe_customer = customer.stripe_customer
+    stripe_invoices = stripe.Invoice.list(customer=stripe_customer.id)
+    for invoice in stripe_invoices.data:
         sync_invoice_from_stripe_data(invoice, send_receipt=False)
 
 

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -1667,18 +1667,16 @@ class SyncsTests(TestCase):
         self.assertTrue(PurgeLocalMock.called)
 
     @patch("pinax.stripe.actions.invoices.sync_invoice_from_stripe_data")
-    @patch("stripe.Invoice.list")
-    @patch("stripe.Customer.retrieve")
-    def test_sync_invoices_for_customer(self, RetreiveMock, InvoicesMock, SyncMock):
-        RetreiveMock().invoices().data = [Mock()]
-        InvoicesMock().data = [Mock()]
+    @patch("stripe.Invoice.auto_paging_iter")
+    def test_sync_invoices_for_customer(self, RetreiveMock, SyncMock):
+        RetreiveMock.return_value = [Mock()]
         invoices.sync_invoices_for_customer(self.customer)
         self.assertTrue(SyncMock.called)
 
     @patch("pinax.stripe.actions.charges.sync_charge_from_stripe_data")
-    @patch("stripe.Customer.retrieve")
+    @patch("stripe.Charge.auto_paging_iter")
     def test_sync_charges_for_customer(self, RetreiveMock, SyncMock):
-        RetreiveMock().charges().data = [Mock()]
+        RetreiveMock.return_value = [Mock()]
         charges.sync_charges_for_customer(self.customer)
         self.assertTrue(SyncMock.called)
 

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -1667,9 +1667,11 @@ class SyncsTests(TestCase):
         self.assertTrue(PurgeLocalMock.called)
 
     @patch("pinax.stripe.actions.invoices.sync_invoice_from_stripe_data")
+    @patch("stripe.Invoice.list")
     @patch("stripe.Customer.retrieve")
-    def test_sync_invoices_for_customer(self, RetreiveMock, SyncMock):
+    def test_sync_invoices_for_customer(self, RetreiveMock, InvoicesMock, SyncMock):
         RetreiveMock().invoices().data = [Mock()]
+        InvoicesMock().data = [Mock()]
         invoices.sync_invoices_for_customer(self.customer)
         self.assertTrue(SyncMock.called)
 

--- a/tox.ini
+++ b/tox.ini
@@ -62,3 +62,5 @@ setenv =
 passenv =
 commands =
     django-admin makemigrations --check -v3 --dry-run --noinput pinax_stripe
+deps =
+    Django < 2.2

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps =
     flake8 == 3.4.1
     flake8-isort == 2.2.2
     flake8-quotes == 0.11.0
+    isort < 4.3.5
 
 [testenv:check_migrated]
 setenv =


### PR DESCRIPTION
#### What's this PR do?

The invoices method was removed on the stripe.Customer object in https://github.com/stripe/stripe-python/commit/d416e9e68c8eba804535541ce29d2d8f2d22b08c

This replaces that same logic to fetch the invoices and sync them and
does it within the method itself. This should be backwards compatible
with stripe-python < 2.0 as well as the 2.0 and up release.

#### Any background context you want to provide?

#### What ticket or issue # does this fix?

Closes #582
Closes #623

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [x] Has the appropriate documentation been updated (if applicable)?
- [x] Have you written tests to prove this change works (if applicable)?
