### PR TITLE
Remove unexisting name from plan data for Synchronizes a plan action

### DIFF
--- a/pinax/stripe/actions/plans.py
+++ b/pinax/stripe/actions/plans.py
@@ -26,7 +26,6 @@ def sync_plan(plan, event=None):
         "currency": plan["currency"] or "",
         "interval": plan["interval"],
         "interval_count": plan["interval_count"],
-        "name": plan["name"],
         "statement_descriptor": plan["statement_descriptor"] or "",
         "trial_period_days": plan["trial_period_days"],
         "metadata": plan["metadata"]


### PR DESCRIPTION
#### What's this PR do?
Remove `name` from dict used for synchronize a plan.
#### Any background context you want to provide?
Plan object does not come with name property and makes the plan signals to fail. More information in Stripe Docs: https://stripe.com/docs/api/plans#plan_object
#### What ticket or issue # does this fix?

Closes #[issue number]

#### Definition of Done (check if considered and/or addressed):

- [ ] Are all backwards incompatible changes documented in this PR?
- [ ] Have all new dependencies been documented in this PR?
- [ ] Has the appropriate documentation been updated (if applicable)?
- [ ] Have you written tests to prove this change works (if applicable)?
