### PR TITLE
WIP: Remove unexisting name from plan data for Synchronizes a plan action

### DIFF
--- a/pinax/stripe/actions/plans.py
+++ b/pinax/stripe/actions/plans.py
@@ -26,7 +26,6 @@ def sync_plan(plan, event=None):
         "currency": plan["currency"] or "",
         "interval": plan["interval"],
         "interval_count": plan["interval_count"],
-        "name": plan["name"],
         "statement_descriptor": plan["statement_descriptor"] or "",
         "trial_period_days": plan["trial_period_days"],
         "metadata": plan["metadata"]

--- a/pinax/stripe/actions/plans.py
+++ b/pinax/stripe/actions/plans.py
@@ -23,10 +23,10 @@ def sync_plan(plan, event=None):
 
     defaults = {
         "amount": utils.convert_amount_for_db(plan["amount"], plan["currency"]),
-        "currency": plan["currency"] or "",
+        "currency": plan.get("currency", ""),
         "interval": plan["interval"],
         "interval_count": plan["interval_count"],
-        "statement_descriptor": plan["statement_descriptor"] or "",
+        "statement_descriptor": plan.get("statement_descriptor", ""),
         "trial_period_days": plan["trial_period_days"],
         "metadata": plan["metadata"]
     }

--- a/pinax/stripe/tests/__init__.py
+++ b/pinax/stripe/tests/__init__.py
@@ -145,7 +145,6 @@ PLAN_CREATED_TEST_DATA = {
             "object": "plan",
             "currency": "usd",
             "created": 1498573686,
-            "name": "Pro Plan",
             "metadata": {}
         }
     },

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -1293,13 +1293,11 @@ class SyncsTests(TestCase):
             "interval_count": 1,
             "livemode": False,
             "metadata": {},
-            "name": "Gold Plan",
             "statement_descriptor": "ALTMAN",
             "trial_period_days": 3
         }
         plans.sync_plan(plan)
         self.assertTrue(Plan.objects.all().count(), 1)
-        self.assertEqual(Plan.objects.get(stripe_id="pro2").name, plan["name"])
 
     def test_sync_payment_source_from_stripe_data_card(self):
         source = {

--- a/pinax/stripe/tests/test_webhooks.py
+++ b/pinax/stripe/tests/test_webhooks.py
@@ -346,7 +346,7 @@ class PlanUpdatedWebhookTest(TestCase):
         )
         registry.get(event.kind)(event).process()
         plan = Plan.objects.get(stripe_id="gold1")
-        self.assertEqual(plan.name, PLAN_CREATED_TEST_DATA["data"]["object"]["name"])
+        self.assertEqual(plan.stripe_id, PLAN_CREATED_TEST_DATA["data"]["object"]["id"])
 
 
 class CustomerSubscriptionCreatedWebhookTest(TestCase):


### PR DESCRIPTION
#### What's this PR do?
Remove `name` from dict used for synchronize a plan.
#### Any background context you want to provide?
Plan object does not come with name property and makes the plan signals to fail. More information in Stripe Docs: https://stripe.com/docs/api/plans#plan_object
#### What ticket or issue # does this fix?

Closes #[issue number]

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [x] Has the appropriate documentation been updated (if applicable)?
- [x] Have you written tests to prove this change works (if applicable)?
