### PR TITLE
Start of adding tests for django 2.2

### DIFF
--- a/pinax/stripe/tests/settings.py
+++ b/pinax/stripe/tests/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.messages",
     "django.contrib.sessions",
     "django.contrib.sites",
     "jsonfield",
@@ -52,6 +53,7 @@ TEMPLATES = [{
             "django.template.context_processors.static",
             "django.template.context_processors.tz",
             "django.template.context_processors.request",
+            "django.contrib.messages.context_processors.messages",
         ],
     },
 }]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envlist =
     py27-dj{18,110,111}
     py34-dj{18,110,111,20}
     py35-dj{18,110,111,20}
-    py36-dj{111,20}
+    py36-dj{111,20,21,22}
 
 [testenv]
 extras = testing
@@ -37,6 +37,8 @@ deps =
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11a1,<2.0
     dj20: Django<2.1
+    dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<2.3
     master: https://github.com/django/django/tarball/master
     postgres: psycopg2-binary
 usedevelop = True


### PR DESCRIPTION
#### What's this PR do?

Starts testing pinax-stripe against Django 2.2 (and Django 2.1 explicitly)

#### Any background context you want to provide?

The test configuration was not testing against the most recent version of Django.

#### What ticket or issue # does this fix?

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [x] Has the appropriate documentation been updated (if applicable)?
- [x] Have you written tests to prove this change works (if applicable)?
