### PR TITLE
update to import unicode_support from six 

### DIFF
--- a/pinax/stripe/models.py
+++ b/pinax/stripe/models.py
@@ -6,7 +6,7 @@ import decimal
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 


### PR DESCRIPTION
Same issue discussed for pinax-blog:

import error installing with django 3.0.4:
cannot import name 'python_2_unicode_compatible' from 'django.utils.encoding

Issue:
Django 3 has removed the django.utils.encoding.python_2_unicode_compatible() api.

Solution:
update pinax/stripe/models.py:

replace: from django.utils.encoding import python_2_unicode_compatible
with: from six import python_2_unicode_compatible

original comment from @dannyblaker
from https://github.com/pinax/pinax-blog/issues/128

same workaround seems to work for pinax-stripe so suggesting the update.